### PR TITLE
Round current time to the closest time defined by step option in the future

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -649,7 +649,7 @@
 								var now = new Date(),
                   currentHours = _xdsoft_datetime.currentTime.getHours(),
                   currentMinutes = _xdsoft_datetime.currentTime.getMinutes(),
-                  roundMinutes = Math.ceil(_xdsoft_datetime.closestTime.getMinutes()/options.step)*options.step,
+                  roundMinutes = currentMinutes >= 50 ? 0 : Math.ceil(_xdsoft_datetime.closestTime.getMinutes()/options.step)*options.step,
                   roundHours = roundMinutes === 0 ? (currentHours == 23 ? 0 : currentHours + 1) : currentHours;
                   
 								now.setHours(h);


### PR DESCRIPTION
With the current solution when you provide the step option, the default time
is selected as the closed time to the current time in the past instead of the future.
for example:
current time: 11:25, step: 10, widget shows 11:20 as default value instead of 11:30.

PS. I'm not very familiar with your plugin. Could you make sure the changes I made are fine?
