### PR TITLE
Fix for issue #44

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -576,6 +576,12 @@
 							_this.currentTime.setFullYear(_this.currentTime.getFullYear()+1);
 							month = 0;
 						}
+						_this.currentTime.setDate(
+							Math.min(
+								Date.daysInMonth[month],
+								_this.currentTime.getDate()
+							)
+						)
 						_this.currentTime.setMonth(month);
 						options.onChangeMonth&&options.onChangeMonth.call&&options.onChangeMonth.call(datetimepicker,_xdsoft_datetime.currentTime,datetimepicker.data('input'));
 						datetimepicker.trigger('xchange.xdsoft');
@@ -588,6 +594,12 @@
 							_this.currentTime.setFullYear(_this.currentTime.getFullYear()-1);
 							month = 11;
 						}
+						_this.currentTime.setDate(
+							Math.min(
+								Date.daysInMonth[month],
+								_this.currentTime.getDate()
+							)
+						)
 						_this.currentTime.setMonth(month);
 						options.onChangeMonth&&options.onChangeMonth.call&&options.onChangeMonth.call(datetimepicker,_xdsoft_datetime.currentTime,datetimepicker.data('input'));
 						datetimepicker.trigger('xchange.xdsoft');
@@ -830,8 +842,8 @@
 							return false;
 
 						currentTime.setFullYear( $this.data('year') );
-						currentTime.setMonth( $this.data('month') );
 						currentTime.setDate( $this.data('date') );
+						currentTime.setMonth( $this.data('month') );
 						datetimepicker.trigger('select.xdsoft',[currentTime]);
 
 						input.val( _xdsoft_datetime.str() );


### PR DESCRIPTION
When you set the month in JS, if the current day is greater than the number
days in the new month, the date will be updated to acccount for that by
bumping the date out to the next month.

e.g. (Jan 30).setMonth(1) will result in Mar 2 since Feb only has 28 days.

The proposed fix sets the date first to be never more than the potential
number of days in the month, then sets the month.

Also, for direct access to the month, we set the desired day first THEN
the desired month. This accounts for the case where you are on Jan 30, then
hit the "1" for February and it jumps to march.
