### PR TITLE
Fixed incorrect date when selecting previous month

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -862,8 +862,8 @@
 							return false;
 
 						currentTime.setFullYear( $this.data('year') );
-						currentTime.setDate( $this.data('date') );
 						currentTime.setMonth( $this.data('month') );
+						currentTime.setDate( $this.data('date') );
 						datetimepicker.trigger('select.xdsoft',[currentTime]);
 
 						input.val( _xdsoft_datetime.str() );


### PR DESCRIPTION
This commit is fixing a bug which occured during date selection. When selecting a day of the previous month which is higher than the current date's day the wrong date will be selected. This happens because setting a day with setDate() which is higher than the current month will automatically change the day to a lower number. That's why the month has to be set before the day.

How to reproduce: Let's say February, 26th is selected and then the user wants to switch to January, 30th then January, 2nd will be selected instead.
