### PR TITLE
Do not scroll over the document top edge

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -988,6 +988,8 @@
 					var offset = datetimepicker.data('input').offset(), top = offset.top+datetimepicker.data('input')[0].offsetHeight-1, left = offset.left;
 					if( top+datetimepicker[0].offsetHeight>$(window).height()+$(window).scrollTop() )
 						top = offset.top-datetimepicker[0].offsetHeight+1;
+						if (top < 0)
+							top = 0;
 					if( left+datetimepicker[0].offsetWidth>$(window).width() )
 						left = offset.left-datetimepicker[0].offsetWidth+datetimepicker.data('input')[0].offsetWidth;
 					datetimepicker.css({


### PR DESCRIPTION
With this simple if statement datepicker div will not appear
over the document top edge. 
It was happening especially when working with small iframes.
