### PR TITLE
Option to stop continuous month change on mouse down

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -164,7 +164,7 @@
 		//fromUnixtime:	false,
 		
 		step:60,
-		
+		monthChangeSpinner:true,
 		closeOnDateSelect:false,
 		closeOnWithoutClick:true,
 		
@@ -792,7 +792,9 @@
 								}else if( $this.hasClass( options.prev ) ) {
 									_xdsoft_datetime.prevMonth();
 								}
-								!stop&&(timer = setTimeout(arguments_callee1,v?v:100));
+								if (options.monthChangeSpinner) {
+									!stop&&(timer = setTimeout(arguments_callee1,v?v:100));
+								}
 							})(500);
 
 							$([document.body,window]).on('mouseup.xdsoft',function arguments_callee2() {


### PR DESCRIPTION
On mouse down of prev and next icon of month change, the month keeps on changing and stops on mouse up event. With monthChangeSpinner option, it can be disabled by using "monthChangeSpinner" option: 
$('#datetimepicker3').datetimepicker({
    monthChangeSpinner:false
});

Default value is true, if set to false the month continuous change will stop and only one month can be changed in one mouse down event.
We faced a problem in firefox browser where on month change, lot of processing was required in the project along with an ajax cal for loading data from server for the month. In that case the month change was unstoppable and was continuously changing the months from May to Apr then Mar then Feb and so on.
