### PR TITLE
Time Scroller Issue

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -468,7 +468,9 @@
 					if( options.inline ) {
 						datetimepicker.addClass('xdsoft_inline');
 						input.after(datetimepicker).hide();
-						datetimepicker.trigger('afterOpen.xdsoft');
+						setTimeout(function() {
+							datetimepicker.trigger('afterOpen.xdsoft');
+						}, 100);
 					}
 
 					if( options.inverseButton ) {


### PR DESCRIPTION
Upon initialization the height of the time scroller container is zero. So the margin will not be set successfully when using the picker to be displayed inline! So timing out to 100 millisecond the container will be filled and it will take its actual height and there will be no problems with time scroller when using "inline" option
