### PR TITLE
Added option to fix the position of picker.

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -241,6 +241,8 @@
 		style:'',
 		id:'',
 		
+		fixed: false,
+		
 		roundTime:'round', // ceil, floor
 		className:'',
 		
@@ -1160,16 +1162,23 @@
 					}
 				});
 				var setPos = function() {
-					var offset = datetimepicker.data('input').offset(), top = offset.top+datetimepicker.data('input')[0].offsetHeight-1, left = offset.left;
-					if( top+datetimepicker[0].offsetHeight>$(window).height()+$(window).scrollTop() )
-						top = offset.top-datetimepicker[0].offsetHeight+1;
-						if (top < 0)
-							top = 0;
-					if( left+datetimepicker[0].offsetWidth>$(window).width() )
-						left = offset.left-datetimepicker[0].offsetWidth+datetimepicker.data('input')[0].offsetWidth;
+					var offset = datetimepicker.data('input').offset(), top = offset.top+datetimepicker.data('input')[0].offsetHeight-1, left = offset.left, position = "absolute";
+					if (options.fixed) {
+						top -= $(window).scrollTop();
+						left -= $(window).scrollLeft();
+						position = "fixed";
+					}else {
+						if( top+datetimepicker[0].offsetHeight>$(window).height()+$(window).scrollTop() )
+							top = offset.top-datetimepicker[0].offsetHeight+1;
+							if (top < 0)
+								top = 0;
+						if( left+datetimepicker[0].offsetWidth>$(window).width() )
+							left = offset.left-datetimepicker[0].offsetWidth+datetimepicker.data('input')[0].offsetWidth;
+					}
 					datetimepicker.css({
 						left:left,
-						top:top
+						top:top,
+						position: position
 					});
 				};
 				datetimepicker


### PR DESCRIPTION
Example: If the datetimepicker is being used on a fixed position popup,
then we can set fixed: true for the datetimepicker to fix the position
of the picker too.
