### PR TITLE
Making default options modifiable

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1318,6 +1318,7 @@
 				}
 		});
 	};
+	$.fn.datetimepicker.defaults = default_options;
 })( jQuery );
 
 /*


### PR DESCRIPTION
Storing default options in global object, so that any one can access or modify it easily using jQuery's "$.extend()" method as below :

$.extend($.fn.datetimepicker.defaults, {
       format : "d/m/Y h:i A",
       ....
})

So we don't have to specify the same options again and again, it will automatically get reflected to all the newly created datetimepicker objects.
