### PR TITLE
Add ability to toggle datetimepicker

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1484,6 +1484,9 @@
 					}
 					event.stopPropagation();
 				})
+				.on('toggle.xdsoft', function (event) {
+					datetimepicker.is(':visible') ? datetimepicker.trigger('close.xdsoft') : datetimepicker.trigger('open.xdsoft');
+				})
 				.data('input', input);
 
 			timer = 0;
@@ -1594,6 +1597,9 @@
 						break;
 					case 'hide':
 						datetimepicker.trigger('close.xdsoft');
+						break;
+					case 'toggle':
+						datetimepicker.trigger('toggle.xdsoft');
 						break;
 					case 'destroy':
 						destroyDateTimePicker($(this));


### PR DESCRIPTION
For my application, I wanted a button that could toggle the datetimepicker. Very simple usage

`options.closeOnWithoutClick` enabled

``` javascript
$("#button").on('mousedown', function() {
    $("#picker").datetimepicker("toggle");
    return false;
});
```

`options.closeOnWithoutClick` disabled

``` javascript
$("#button").on('click', function() {
    $("#picker").datetimepicker("toggle");
});
```

This is good for what I need right now, but it doesn't work with `lazyInit`. If `lazyInit` is on and the picker hasn't been initialized yet, `.datetimepicker("toggle")` won't do anything.

I think it's a pretty common need for people to want an icon button next to the input field that people can click on to toggle the picker. In my application, it's a bootstrap `.input-group-addon`. If you think it's a good idea, I can also prepare a PR with a `toggleButton` option where you could set a button that would work with lazyInit
