### PR TITLE
remove jquery.js from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
 		"**/*.txt",
 		"**/*.md",
 		"**/*.html",
-		"**/*.tpl"
+		"**/*.tpl",
+		"**/jquery.js"
 	  ],
 	"keywords": [
 		"calendar",


### PR DESCRIPTION
Maybe it's a personal preference thing - but is it necessary to have jquery.js included in the download?
