### PR TITLE
Fixed weekends problem #204

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1358,7 +1358,7 @@
 								classes.push('xdsoft_today');
 							}
 
-							if (start.getDay() === 0 || start.getDay() === 6 || options.weekends.indexOf(start.dateFormat(options.formatDate)) === -1) {
+							if (start.getDay() === 0 || start.getDay() === 6 && options.weekends.indexOf(start.dateFormat(options.formatDate)) === -1) {
 								classes.push('xdsoft_weekend');
 							}
 


### PR DESCRIPTION
Before, every single day is marked as weekends. Making it impossible to
disable weekends on the date picker. Fixed this issue by changing the or to an and (see code)

Issue #204