### PR TITLE
Create several datetimepickers with class selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
 	<p><a href="http://xdsoft.net/jqplugins/datetimepicker/">Homepage</a></p>
 	<h3>DateTimePicker</h3>
 	<input type="text" value="" id="datetimepicker"/><br><br>
+  <h3>DateTimePickers selected by class</h3>
+	<input type="text" class="some_class" value="" id="some_class_1"/>
+	<input type="text" class="some_class" value="" id="some_class_2"/>
 	<h3>Mask DateTimePicker</h3>
 	<input type="text" value="" id="datetimepicker_mask"/><br><br>
 	<h3>TimePicker</h3>
@@ -68,6 +71,8 @@ disabledDates:['1986/01/08','1986/01/09','1986/01/10'],
 startDate:	'1986/01/05'
 });
 $('#datetimepicker').datetimepicker({value:'2015/04/15 05:03',step:10});
+
+$('.some_class').datetimepicker();
 
 $('#default_datetimepicker').datetimepicker({
 	formatTime:'H:i',

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -690,7 +690,6 @@
 			lazyInitTimer = 0,
 			createDateTimePicker,
 			destroyDateTimePicker,
-			_xdsoft_datetime,
 
 			lazyInit = function (input) {
 				input
@@ -735,7 +734,8 @@
 				current_time_index,
 				setPos,
 				timer = 0,
-				timer1 = 0;
+				timer1 = 0,
+				_xdsoft_datetime;
 
 			mounth_picker
 				.find('.xdsoft_month span')


### PR DESCRIPTION
Fixes Issue #201 by moving _xdsoft_datetime declaration from
$.fn.datetimepicker() down into its createDateTimePicker().

With this fix, the next/prev month arrows work in all of datetimepickers
created with the class selector.
