### PR TITLE
Do not check whether input is visible

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -694,7 +694,7 @@
 			lazyInit = function (input) {
 				input
 					.on('open.xdsoft focusin.xdsoft mousedown.xdsoft', function initOnActionCallback(event) {
-						if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible') || input.data('xdsoft_datetimepicker')) {
+						if (input.is(':disabled') || input.data('xdsoft_datetimepicker')) {
 							return;
 						}
 						clearTimeout(lazyInitTimer);
@@ -1722,12 +1722,12 @@
 			input
 				.data('xdsoft_datetimepicker', datetimepicker)
 				.on('open.xdsoft focusin.xdsoft mousedown.xdsoft', function (event) {
-					if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible') || (input.data('xdsoft_datetimepicker').is(':visible') && options.closeOnInputClick)) {
+					if (input.is(':disabled') || (input.data('xdsoft_datetimepicker').is(':visible') && options.closeOnInputClick)) {
 						return;
 					}
 					clearTimeout(timer);
 					timer = setTimeout(function () {
-						if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible')) {
+						if (input.is(':disabled')) {
 							return;
 						}
 


### PR DESCRIPTION
Because it's buggy in chrome. For example if I want initialize datepicker for empty inline element.
