### PR TITLE
Fix for IE8 issue #41

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -792,9 +792,9 @@
 				})
 				.on('mousedown.xdsoft', '.xdsoft_option', function (event) {
 
-				  if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
-				    _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-				  }
+					if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+						_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+					}
 
 					var year = _xdsoft_datetime.currentTime.getFullYear();
 					if (_xdsoft_datetime && _xdsoft_datetime.currentTime) {
@@ -1116,9 +1116,9 @@
 
 				_this.nextMonth = function () {
 
-				  if (_this.currentTime === undefined || _this.currentTime === null) {
-				    _this.currentTime = _this.now();
-				  }
+					if (_this.currentTime === undefined || _this.currentTime === null) {
+						_this.currentTime = _this.now();
+					}
 
 					var month = _this.currentTime.getMonth() + 1,
 						year;
@@ -1151,9 +1151,9 @@
 
 				_this.prevMonth = function () {
 
-				  if (_this.currentTime === undefined || _this.currentTime === null) {
-				    _this.currentTime = _this.now();
-				  }
+					if (_this.currentTime === undefined || _this.currentTime === null) {
+						_this.currentTime = _this.now();
+					}
 
 					var month = _this.currentTime.getMonth() - 1;
 					if (month === -1) {
@@ -1309,11 +1309,11 @@
 					clearTimeout(xchangeTimer);
 					xchangeTimer = setTimeout(function () {
 
-					  if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
-					    _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-					  }
+						if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+							_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+						}
 
-					  var table =	'',
+						var table =	'',
 							start = new Date(_xdsoft_datetime.currentTime.getFullYear(), _xdsoft_datetime.currentTime.getMonth(), 1, 12, 0, 0),
 							i = 0,
 							j,

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -791,6 +791,11 @@
 					event.preventDefault();
 				})
 				.on('mousedown.xdsoft', '.xdsoft_option', function (event) {
+
+				  if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+				    _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+				  }
+
 					var year = _xdsoft_datetime.currentTime.getFullYear();
 					if (_xdsoft_datetime && _xdsoft_datetime.currentTime) {
 						_xdsoft_datetime.currentTime[$(this).parent().parent().hasClass('xdsoft_monthselect') ? 'setMonth' : 'setFullYear']($(this).data('value'));
@@ -1110,6 +1115,11 @@
 				};
 
 				_this.nextMonth = function () {
+
+				  if (_this.currentTime === undefined || _this.currentTime === null) {
+				    _this.currentTime = _this.now();
+				  }
+
 					var month = _this.currentTime.getMonth() + 1,
 						year;
 					if (month === 12) {
@@ -1140,6 +1150,11 @@
 				};
 
 				_this.prevMonth = function () {
+
+				  if (_this.currentTime === undefined || _this.currentTime === null) {
+				    _this.currentTime = _this.now();
+				  }
+
 					var month = _this.currentTime.getMonth() - 1;
 					if (month === -1) {
 						_this.currentTime.setFullYear(_this.currentTime.getFullYear() - 1);
@@ -1238,7 +1253,7 @@
 						stop = false;
 
 					(function arguments_callee1(v) {
-						var month =  _xdsoft_datetime.currentTime.getMonth();
+						//var month =  _xdsoft_datetime.currentTime.getMonth();
 						if ($this.hasClass(options.next)) {
 							_xdsoft_datetime.nextMonth();
 						} else if ($this.hasClass(options.prev)) {
@@ -1294,7 +1309,12 @@
 				.on('xchange.xdsoft', function (event) {
 					clearTimeout(xchangeTimer);
 					xchangeTimer = setTimeout(function () {
-						var table =	'',
+
+					  if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+					    _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+					  }
+
+					  var table =	'',
 							start = new Date(_xdsoft_datetime.currentTime.getFullYear(), _xdsoft_datetime.currentTime.getMonth(), 1, 12, 0, 0),
 							i = 0,
 							j,

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1253,7 +1253,6 @@
 						stop = false;
 
 					(function arguments_callee1(v) {
-						//var month =  _xdsoft_datetime.currentTime.getMonth();
 						if ($this.hasClass(options.next)) {
 							_xdsoft_datetime.nextMonth();
 						} else if ($this.hasClass(options.prev)) {


### PR DESCRIPTION
To reproduce, attempt to click forward or back on the popup calendar and the input textbox is empty using IE8. This commit adds a null check and defaults the null date to current date time. 
Was not tested with max and min dates specified. Not sure of behavior there.