### PR TITLE
Fix to prevent times such as `12:60` instead of `13:00` when using an input of `xx:45 - xx:59`

### DIFF
--- a/jquery.datetimepicker.css
+++ b/jquery.datetimepicker.css
@@ -314,6 +314,7 @@
 .xdsoft_datetimepicker .xdsoft_time_box >div >div.xdsoft_disabled {
 	opacity: 0.5;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+    cursor: default;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_other_month.xdsoft_disabled {
@@ -326,6 +327,13 @@
 	color: #fff !important;
     background: #ff8000 !important;
     box-shadow: none !important;
+}
+
+.xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_current.xdsoft_disabled:hover,
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box>div>div.xdsoft_current.xdsoft_disabled:hover {
+    background: #33aaff !important;
+    box-shadow: #178fe5 0 1px 3px 0 inset !important;
+    color: #fff !important;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_disabled:hover,

--- a/jquery.datetimepicker.css
+++ b/jquery.datetimepicker.css
@@ -1,12 +1,12 @@
-.xdsoft_datetimepicker{
+.xdsoft_datetimepicker {
 	box-shadow: 0 5px 15px -5px rgba(0, 0, 0, 0.506);
-	background: #FFFFFF;
-	border-bottom: 1px solid #BBBBBB;
-	border-left: 1px solid #CCCCCC;
-	border-right: 1px solid #CCCCCC;
-	border-top: 1px solid #CCCCCC;
-	color: #333333;
-	font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+	background: #fff;
+	border-bottom: 1px solid #bbb;
+	border-left: 1px solid #ccc;
+	border-right: 1px solid #ccc;
+	border-top: 1px solid #ccc;
+	color: #333;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	padding: 8px;
 	padding-left: 0;
 	padding-top: 2px;
@@ -14,7 +14,7 @@
 	z-index: 9999;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
-	display:none;
+	display: none;
 }
 
 .xdsoft_datetimepicker iframe {
@@ -24,14 +24,15 @@
     width: 75px;
     height: 210px;
     background: transparent;
-    border:none;
-}
-/*For IE8 or lower*/
-.xdsoft_datetimepicker button {
-    border:none !important;
+    border: none;
 }
 
-.xdsoft_noselect{
+/*For IE8 or lower*/
+.xdsoft_datetimepicker button {
+    border: none !important;
+}
+
+.xdsoft_noselect {
 	-webkit-touch-callout: none;
 	-webkit-user-select: none;
 	-khtml-user-select: none;
@@ -40,92 +41,102 @@
 	-o-user-select: none;
 	user-select: none;
 }
-.xdsoft_noselect::selection { background: transparent; }
-.xdsoft_noselect::-moz-selection { background: transparent; }
-.xdsoft_datetimepicker.xdsoft_inline{
+
+.xdsoft_noselect::selection { background: transparent }
+.xdsoft_noselect::-moz-selection { background: transparent }
+
+.xdsoft_datetimepicker.xdsoft_inline {
 	display: inline-block;
 	position: static;
 	box-shadow: none;
 }
-.xdsoft_datetimepicker *{
+
+.xdsoft_datetimepicker * {
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	padding: 0;
 	margin: 0;
 }
-.xdsoft_datetimepicker .xdsoft_datepicker, .xdsoft_datetimepicker  .xdsoft_timepicker{
-	display:none;
+
+.xdsoft_datetimepicker .xdsoft_datepicker, .xdsoft_datetimepicker .xdsoft_timepicker {
+	display: none;
 }
-.xdsoft_datetimepicker .xdsoft_datepicker.active, .xdsoft_datetimepicker  .xdsoft_timepicker.active{
-	display:block;
+
+.xdsoft_datetimepicker .xdsoft_datepicker.active, .xdsoft_datetimepicker .xdsoft_timepicker.active {
+	display: block;
 }
-.xdsoft_datetimepicker .xdsoft_datepicker{
+
+.xdsoft_datetimepicker .xdsoft_datepicker {
 	width: 224px;
-	float:left;
-	margin-left:8px;
+	float: left;
+	margin-left: 8px;
 }
-.xdsoft_datetimepicker.xdsoft_showweeks .xdsoft_datepicker{
+
+.xdsoft_datetimepicker.xdsoft_showweeks .xdsoft_datepicker {
 	width: 256px;
 }
-.xdsoft_datetimepicker  .xdsoft_timepicker{
+
+.xdsoft_datetimepicker .xdsoft_timepicker {
 	width: 58px;
-	float:left;
-	text-align:center;
-	margin-left:8px;
+	float: left;
+	text-align: center;
+	margin-left: 8px;
 	margin-top: 0;
 }
-.xdsoft_datetimepicker  .xdsoft_datepicker.active+.xdsoft_timepicker{
-	margin-top:8px;
-	margin-bottom:3px
+
+.xdsoft_datetimepicker .xdsoft_datepicker.active+.xdsoft_timepicker {
+	margin-top: 8px;
+	margin-bottom: 3px
 }
-.xdsoft_datetimepicker  .xdsoft_mounthpicker{
+
+.xdsoft_datetimepicker .xdsoft_mounthpicker {
 	position: relative;
 	text-align: center;
 }
 
 .xdsoft_datetimepicker .xdsoft_label i,
-.xdsoft_datetimepicker  .xdsoft_prev, 
-.xdsoft_datetimepicker  .xdsoft_next,
-.xdsoft_datetimepicker  .xdsoft_today_button{
+.xdsoft_datetimepicker .xdsoft_prev,
+.xdsoft_datetimepicker .xdsoft_next,
+.xdsoft_datetimepicker .xdsoft_today_button {
 	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAAAeCAYAAADaW7vzAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6Q0NBRjI1NjM0M0UwMTFFNDk4NkFGMzJFQkQzQjEwRUIiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6Q0NBRjI1NjQ0M0UwMTFFNDk4NkFGMzJFQkQzQjEwRUIiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpDQ0FGMjU2MTQzRTAxMUU0OTg2QUYzMkVCRDNCMTBFQiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpDQ0FGMjU2MjQzRTAxMUU0OTg2QUYzMkVCRDNCMTBFQiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PoNEP54AAAIOSURBVHja7Jq9TsMwEMcxrZD4WpBYeKUCe+kTMCACHZh4BFfHO/AAIHZGFhYkBBsSEqxsLCAgXKhbXYOTxh9pfJVP+qutnZ5s/5Lz2Y5I03QhWji2GIcgAokWgfCxNvcOCCGKqiSqhUp0laHOne05vdEyGMfkdxJDVjgwDlEQgYQBgx+ULJaWSXXS6r/ER5FBVR8VfGftTKcITNs+a1XpcFoExREIDF14AVIFxgQUS+h520cdud6wNkC0UBw6BCO/HoCYwBhD8QCkQ/x1mwDyD4plh4D6DDV0TAGyo4HcawLIBBSLDkHeH0Mg2yVP3l4TQMZQDDsEOl/MgHQqhMNuE0D+oBh0CIr8MAKyazBH9WyBuKxDWgbXfjNf32TZ1KWm/Ap1oSk/R53UtQ5xTh3LUlMmT8gt6g51Q9p+SobxgJQ/qmsfZhWywGFSl0yBjCLJCMgXail3b7+rumdVJ2YRss4cN+r6qAHDkPWjPjdJCF4n9RmAD/V9A/Wp4NQassDjwlB6XBiCxcJQWmZZb8THFilfy/lfrTvLghq2TqTHrRMTKNJ0sIhdo15RT+RpyWwFdY96UZ/LdQKBGjcXpcc1AlSFEfLmouD+1knuxBDUVrvOBmoOC/rEcN7OQxKVeJTCiAdUzUJhA2Oez9QTkp72OTVcxDcXY8iKNkxGAJXmJCOQwOa6dhyXsOa6XwEGAKdeb5ET3rQdAAAAAElFTkSuQmCC);
 }
 
-.xdsoft_datetimepicker .xdsoft_label i{
-	opacity:0.5;
-	background-position:-92px -19px;
+.xdsoft_datetimepicker .xdsoft_label i {
+	opacity: 0.5;
+	background-position: -92px -19px;
 	display: inline-block;
 	width: 9px;
 	height: 20px;
 	vertical-align: middle;
 }
 
-.xdsoft_datetimepicker  .xdsoft_prev{
+.xdsoft_datetimepicker .xdsoft_prev {
     float: left;
-	background-position:-20px 0;
+	background-position: -20px 0;
 }
-.xdsoft_datetimepicker  .xdsoft_today_button{
+.xdsoft_datetimepicker .xdsoft_today_button {
     float: left;
-	background-position:-70px 0;
-	margin-left:5px;
+	background-position: -70px 0;
+	margin-left: 5px;
 }
 
-.xdsoft_datetimepicker  .xdsoft_next{
+.xdsoft_datetimepicker .xdsoft_next {
     float: right;
 	background-position: 0 0;
 }
 
-.xdsoft_datetimepicker  .xdsoft_next,
-.xdsoft_datetimepicker  .xdsoft_prev ,
-.xdsoft_datetimepicker  .xdsoft_today_button{
+.xdsoft_datetimepicker .xdsoft_next,
+.xdsoft_datetimepicker .xdsoft_prev ,
+.xdsoft_datetimepicker .xdsoft_today_button {
 	background-color: transparent;
 	background-repeat: no-repeat;
-	border: 0 none currentColor;
+	border: 0 none;
 	cursor: pointer;
 	display: block;
 	height: 30px;
 	opacity: 0.5;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
-	outline: medium none currentColor;
+	outline: medium none;
 	overflow: hidden;
 	padding: 0;
 	position: relative;
@@ -133,49 +144,55 @@
 	white-space: nowrap;
 	width: 20px;
 }
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_prev,
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_next{
-	float:none;
-	background-position:-40px -15px;
+
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_prev,
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_next {
+	float: none;
+	background-position: -40px -15px;
 	height: 15px;
 	width: 30px;
 	display: block;
-	margin-left:14px;
-	margin-top:7px;
-}
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_prev{
-	background-position:-40px 0;
-	margin-bottom:7px;
-	margin-top: 0;
-}
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_time_box{
-	height:151px;
-	overflow:hidden;
-	border-bottom:1px solid #DDDDDD;
-}
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_time_box >div >div{
-	background: #F5F5F5;
-	border-top:1px solid #DDDDDD;
-	color: #666666;
-	font-size: 12px;
-	text-align: center;
-	border-collapse:collapse;
-	cursor:pointer;
-	border-bottom-width: 0;
-	height:25px;
-	line-height:25px;
+	margin-left: 14px;
+	margin-top: 7px;
 }
 
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_time_box >div > div:first-child{
- border-top-width: 0;
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_prev {
+	background-position: -40px 0;
+	margin-bottom: 7px;
+	margin-top: 0;
 }
-.xdsoft_datetimepicker  .xdsoft_today_button:hover,
-.xdsoft_datetimepicker  .xdsoft_next:hover,
-.xdsoft_datetimepicker  .xdsoft_prev:hover {
+
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box {
+	height: 151px;
+	overflow: hidden;
+	border-bottom: 1px solid #ddd;
+}
+
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box >div >div {
+	background: #f5f5f5;
+	border-top: 1px solid #ddd;
+	color: #666;
+	font-size: 12px;
+	text-align: center;
+	border-collapse: collapse;
+	cursor: pointer;
+	border-bottom-width: 0;
+	height: 25px;
+	line-height: 25px;
+}
+
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box >div > div:first-child {
+    border-top-width: 0;
+}
+
+.xdsoft_datetimepicker .xdsoft_today_button:hover,
+.xdsoft_datetimepicker .xdsoft_next:hover,
+.xdsoft_datetimepicker .xdsoft_prev:hover {
     opacity: 1;
     -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 }
-.xdsoft_datetimepicker  .xdsoft_label{
+
+.xdsoft_datetimepicker .xdsoft_label {
 	display: inline;
     position: relative;
     z-index: 9999;
@@ -185,234 +202,264 @@
     line-height: 20px;
     font-weight: bold;
     background-color: #fff;
-	float:left;
-	width:182px;
-	text-align:center;
-	cursor:pointer;
+	float: left;
+	width: 182px;
+	text-align: center;
+	cursor: pointer;
 }
-.xdsoft_datetimepicker  .xdsoft_label:hover>span{
-	text-decoration:underline;
+
+.xdsoft_datetimepicker .xdsoft_label:hover>span {
+	text-decoration: underline;
 }
-.xdsoft_datetimepicker  .xdsoft_label:hover i{
-	opacity:1.0;
+
+.xdsoft_datetimepicker .xdsoft_label:hover i {
+	opacity: 1.0;
 }
-.xdsoft_datetimepicker  .xdsoft_label > .xdsoft_select{
-	border:1px solid #ccc;
-	position:absolute;
+
+.xdsoft_datetimepicker .xdsoft_label > .xdsoft_select {
+	border: 1px solid #ccc;
+	position: absolute;
 	right: 0;
-	top:30px;
-	z-index:101;
-	display:none;
-	background:#fff;
-	max-height:160px;
-	overflow-y:hidden;
+	top: 30px;
+	z-index: 101;
+	display: none;
+	background: #fff;
+	max-height: 160px;
+	overflow-y: hidden;
 }
-.xdsoft_datetimepicker  .xdsoft_label > .xdsoft_select.xdsoft_monthselect{right:-7px;}
-.xdsoft_datetimepicker  .xdsoft_label > .xdsoft_select.xdsoft_yearselect{right:2px;}
-.xdsoft_datetimepicker  .xdsoft_label > .xdsoft_select > div > .xdsoft_option:hover{
+
+.xdsoft_datetimepicker .xdsoft_label > .xdsoft_select.xdsoft_monthselect{ right: -7px }
+.xdsoft_datetimepicker .xdsoft_label > .xdsoft_select.xdsoft_yearselect{ right: 2px }
+.xdsoft_datetimepicker .xdsoft_label > .xdsoft_select > div > .xdsoft_option:hover {
 	color: #fff;
     background: #ff8000;
 }
-.xdsoft_datetimepicker  .xdsoft_label > .xdsoft_select > div > .xdsoft_option{
-	padding:2px 10px 2px 5px;
-	text-decoration:none !important;
+
+.xdsoft_datetimepicker .xdsoft_label > .xdsoft_select > div > .xdsoft_option {
+	padding: 2px 10px 2px 5px;
+	text-decoration: none !important;
 }
-.xdsoft_datetimepicker  .xdsoft_label > .xdsoft_select > div > .xdsoft_option.xdsoft_current{
-	background: #33AAFF;
-	box-shadow: #178FE5 0 1px 3px 0 inset;
-	color:#fff;
+
+.xdsoft_datetimepicker .xdsoft_label > .xdsoft_select > div > .xdsoft_option.xdsoft_current {
+	background: #33aaff;
+	box-shadow: #178fe5 0 1px 3px 0 inset;
+	color: #fff;
 	font-weight: 700;
 }
-.xdsoft_datetimepicker  .xdsoft_month{
-	width:100px;
-	text-align:right;
+
+.xdsoft_datetimepicker .xdsoft_month {
+	width: 100px;
+	text-align: right;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar{
-	clear:both;
+
+.xdsoft_datetimepicker .xdsoft_calendar {
+	clear: both;
 }
-.xdsoft_datetimepicker  .xdsoft_year{
+
+.xdsoft_datetimepicker .xdsoft_year{
 	width: 48px;
 	margin-left: 5px;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar table{
-	border-collapse:collapse;
-	width:100%;
-	
+
+.xdsoft_datetimepicker .xdsoft_calendar table {
+	border-collapse: collapse;
+	width: 100%;
+
 }
-.xdsoft_datetimepicker  .xdsoft_calendar td > div{
-	padding-right:5px;
+
+.xdsoft_datetimepicker .xdsoft_calendar td > div {
+	padding-right: 5px;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar th{
+
+.xdsoft_datetimepicker .xdsoft_calendar th {
 	height: 25px;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar td,.xdsoft_datetimepicker  .xdsoft_calendar th{
-	width:14.2857142%;
-	background: #F5F5F5;
-	border:1px solid #DDDDDD;
-	color: #666666;
+
+.xdsoft_datetimepicker .xdsoft_calendar td,.xdsoft_datetimepicker .xdsoft_calendar th {
+	width: 14.2857142%;
+	background: #f5f5f5;
+	border: 1px solid #ddd;
+	color: #666;
 	font-size: 12px;
 	text-align: right;
 	vertical-align: middle;
 	padding: 0;
-	border-collapse:collapse;
-	cursor:pointer;
+	border-collapse: collapse;
+	cursor: pointer;
 	height: 25px;
 }
-.xdsoft_datetimepicker.xdsoft_showweeks  .xdsoft_calendar td,.xdsoft_datetimepicker.xdsoft_showweeks  .xdsoft_calendar th{
-	width:12.5%;
+.xdsoft_datetimepicker.xdsoft_showweeks .xdsoft_calendar td,.xdsoft_datetimepicker.xdsoft_showweeks .xdsoft_calendar th {
+	width: 12.5%;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar th{
-	background: #F1F1F1;
+
+.xdsoft_datetimepicker .xdsoft_calendar th {
+	background: #f1f1f1;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar td.xdsoft_today{
-	color:#33AAFF;
+
+.xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_today {
+	color: #33aaff;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar td.xdsoft_default,
-.xdsoft_datetimepicker  .xdsoft_calendar td.xdsoft_current,
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_time_box >div >div.xdsoft_current{
-	background: #33AAFF;
-	box-shadow: #178FE5 0 1px 3px 0 inset;
-	color:#fff;
+
+.xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_default,
+.xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_current,
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box >div >div.xdsoft_current {
+	background: #33aaff;
+	box-shadow: #178fe5 0 1px 3px 0 inset;
+	color: #fff;
 	font-weight: 700;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar td.xdsoft_other_month,
-.xdsoft_datetimepicker  .xdsoft_calendar td.xdsoft_disabled,
-.xdsoft_datetimepicker  .xdsoft_time_box >div >div.xdsoft_disabled{
-	opacity:0.5;
+
+.xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_other_month,
+.xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_disabled,
+.xdsoft_datetimepicker .xdsoft_time_box >div >div.xdsoft_disabled {
+	opacity: 0.5;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 }
-.xdsoft_datetimepicker  .xdsoft_calendar td.xdsoft_other_month.xdsoft_disabled{
-	opacity:0.2;
+
+.xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_other_month.xdsoft_disabled {
+	opacity: 0.2;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
 }
-.xdsoft_datetimepicker  .xdsoft_calendar td:hover,
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_time_box >div >div:hover{
+
+.xdsoft_datetimepicker .xdsoft_calendar td:hover,
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box >div >div:hover {
 	color: #fff !important;
     background: #ff8000 !important;
     box-shadow: none !important;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar td.xdsoft_disabled:hover,
-.xdsoft_datetimepicker  .xdsoft_timepicker .xdsoft_time_box >div >div.xdsoft_disabled:hover{
+
+.xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_disabled:hover,
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box >div >div.xdsoft_disabled:hover {
 	color: inherit	!important;
     background: inherit !important;
     box-shadow: inherit !important;
 }
-.xdsoft_datetimepicker  .xdsoft_calendar th{
+
+.xdsoft_datetimepicker .xdsoft_calendar th {
 	font-weight: 700;
 	text-align: center;
 	color: #999;
-	cursor:default;
+	cursor: default;
 }
-.xdsoft_datetimepicker  .xdsoft_copyright{ color:#ccc !important; font-size:10px;clear:both;float:none;margin-left:8px;}
-.xdsoft_datetimepicker  .xdsoft_copyright a{ color:#eee !important;}
-.xdsoft_datetimepicker  .xdsoft_copyright a:hover{ color:#aaa !important;}
 
+.xdsoft_datetimepicker .xdsoft_copyright {
+    color: #ccc !important;
+    font-size: 10px;
+    clear: both;
+    float: none;
+    margin-left: 8px;
+}
 
-.xdsoft_time_box{
-	position:relative;
-	border:1px solid #ccc;
+.xdsoft_datetimepicker .xdsoft_copyright a { color: #eee !important }
+.xdsoft_datetimepicker .xdsoft_copyright a:hover { color: #aaa !important }
+
+.xdsoft_time_box {
+	position: relative;
+	border: 1px solid #ccc;
 }
-.xdsoft_scrollbar >.xdsoft_scroller{
-	background:#ccc !important;
-	height:20px;
-	border-radius:3px;
+.xdsoft_scrollbar >.xdsoft_scroller {
+	background: #ccc !important;
+	height: 20px;
+	border-radius: 3px;
 }
-.xdsoft_scrollbar{
-	position:absolute;
-	width:7px;
+.xdsoft_scrollbar {
+	position: absolute;
+	width: 7px;
 	right: 0;
 	top: 0;
 	bottom: 0;
-	cursor:pointer;
+	cursor: pointer;
 }
-.xdsoft_scroller_box{
-position:relative;
+.xdsoft_scroller_box {
+    position: relative;
 }
 
-
-.xdsoft_datetimepicker.xdsoft_dark{
+.xdsoft_datetimepicker.xdsoft_dark {
 	box-shadow: 0 5px 15px -5px rgba(255, 255, 255, 0.506);
-	background: #000000;
-	border-bottom: 1px solid #444444;
-	border-left: 1px solid #333333;
-	border-right: 1px solid #333333;
-	border-top: 1px solid #333333;
-	color: #cccccc;
+	background: #000;
+	border-bottom: 1px solid #444;
+	border-left: 1px solid #333;
+	border-right: 1px solid #333;
+	border-top: 1px solid #333;
+	color: #ccc;
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_timepicker .xdsoft_time_box{
-	border-bottom:1px solid #222222;
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_timepicker .xdsoft_time_box {
+	border-bottom: 1px solid #222;
 }
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_timepicker .xdsoft_time_box >div >div{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_timepicker .xdsoft_time_box >div >div {
 	background: #0a0a0a;
-	border-top:1px solid #222222;
-	color: #999999;
+	border-top: 1px solid #222;
+	color: #999;
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_label{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_label {
     background-color: #000;
 }
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_label > .xdsoft_select{
-	border:1px solid #333;
-	background:#000;
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_label > .xdsoft_select {
+	border: 1px solid #333;
+	background: #000;
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_label > .xdsoft_select > div > .xdsoft_option:hover{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_label > .xdsoft_select > div > .xdsoft_option:hover {
 	color: #000;
     background: #007fff;
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_label > .xdsoft_select > div > .xdsoft_option.xdsoft_current{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_label > .xdsoft_select > div > .xdsoft_option.xdsoft_current {
 	background: #cc5500;
 	box-shadow: #b03e00 0 1px 3px 0 inset;
-	color:#000;
+	color: #000;
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_label i,
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_prev, 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_next,
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_today_button{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_label i,
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_prev,
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_next,
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_today_button {
 	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAAAeCAYAAADaW7vzAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUExQUUzOTA0M0UyMTFFNDlBM0FFQTJENTExRDVBODYiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUExQUUzOTE0M0UyMTFFNDlBM0FFQTJENTExRDVBODYiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpBQTFBRTM4RTQzRTIxMUU0OUEzQUVBMkQ1MTFENUE4NiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpBQTFBRTM4RjQzRTIxMUU0OUEzQUVBMkQ1MTFENUE4NiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pp0VxGEAAAIASURBVHja7JrNSgMxEMebtgh+3MSLr1T1Xn2CHoSKB08+QmR8Bx9A8e7RixdB9CKCoNdexIugxFlJa7rNZneTbLIpM/CnNLsdMvNjM8l0mRCiQ9Ye61IKCAgZAUnH+mU3MMZaHYChBnJUDzWOFZdVfc5+ZFLbrWDeXPwbxIqrLLfaeS0hEBVGIRQCEiZoHQwtlGSByCCdYBl8g8egTTAWoKQMRBRBcZxYlhzhKegqMOageErsCHVkk3hXIFooDgHB1KkHIHVgzKB4ADJQ/A1jAFmAYhkQqA5TOBtocrKrgXwQA8gcFIuAIO8sQSA7hidvPwaQGZSaAYHOUWJABhWWw2EMIH9QagQERU4SArJXo0ZZL18uvaxejXt/Em8xjVBXmvFr1KVm/AJ10tRe2XnraNqaJvKE3KHuUbfK1E+VHB0q40/y3sdQSxY4FHWeKJCunP8UyDdqJZenT3ntVV5jIYCAh20vT7ioP8tpf6E2lfEMwERe+whV1MHjwZB7PBiCxcGQWwKZKD62lfGNnP/1poFAA60T7rF1UgcKd2id3KDeUS+oLWV8DfWAepOfq00CgQabi9zjcgJVYVD7PVzQUAUGAQkbNJTBICDhgwYTjDYD6XeW08ZKh+A4pYkzenOxXUbvZcWz7E8ykRMnIHGX1XPl+1m2vPYpL+2qdb8CDAARlKFEz/ZVkAAAAABJRU5ErkJggg==);
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_calendar td,
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_calendar th{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar td,
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar th {
 	background: #0a0a0a;
-	border:1px solid #222222;
-	color: #999999;
+	border: 1px solid #222;
+	color: #999;
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_calendar th{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar th {
 	background: #0e0e0e;
 }
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_calendar td.xdsoft_today{
-	color:#cc5500;
-}
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_calendar td.xdsoft_default,
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_calendar td.xdsoft_current,
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_timepicker .xdsoft_time_box >div >div.xdsoft_current{
-	background: #cc5500;
-	box-shadow: #b03e00 0 1px 3px 0 inset;
-	color:#000;
+
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar td.xdsoft_today {
+	color: #cc5500;
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_calendar td:hover,
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_timepicker .xdsoft_time_box >div >div:hover{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar td.xdsoft_default,
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar td.xdsoft_current,
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_timepicker .xdsoft_time_box >div >div.xdsoft_current {
+	background: #cc5500;
+	box-shadow: #b03e00 0 1px 3px 0 inset;
+	color: #000;
+}
+
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar td:hover,
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_timepicker .xdsoft_time_box >div >div:hover {
 	color: #000 !important;
     background: #007fff !important;
 }
 
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_calendar th{
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar th {
 	color: #666;
 }
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_copyright{ color:#333 !important;}
-.xdsoft_datetimepicker.xdsoft_dark  .xdsoft_copyright a{ color:#111 !important;}
-.xdsoft_datetimepicker.xdsoft_dark .xdsoft_copyright a:hover{ color:#555 !important;}
 
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_copyright { color: #333 !important }
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_copyright a { color: #111 !important }
+.xdsoft_datetimepicker.xdsoft_dark .xdsoft_copyright a:hover { color: #555 !important }
 
-.xdsoft_dark .xdsoft_time_box{
-	border:1px solid #333;
+.xdsoft_dark .xdsoft_time_box {
+	border: 1px solid #333;
 }
-.xdsoft_dark .xdsoft_scrollbar >.xdsoft_scroller{
-	background:#333 !important;
+
+.xdsoft_dark .xdsoft_scrollbar >.xdsoft_scroller {
+	background: #333 !important;
 }

--- a/jquery.datetimepicker.css
+++ b/jquery.datetimepicker.css
@@ -18,18 +18,18 @@
 }
 
 .xdsoft_datetimepicker iframe {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 75px;
-    height: 210px;
-    background: transparent;
-    border: none;
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 75px;
+	height: 210px;
+	background: transparent;
+	border: none;
 }
 
 /*For IE8 or lower*/
 .xdsoft_datetimepicker button {
-    border: none !important;
+	border: none !important;
 }
 
 .xdsoft_noselect {
@@ -111,17 +111,17 @@
 }
 
 .xdsoft_datetimepicker .xdsoft_prev {
-    float: left;
+	float: left;
 	background-position: -20px 0;
 }
 .xdsoft_datetimepicker .xdsoft_today_button {
-    float: left;
+	float: left;
 	background-position: -70px 0;
 	margin-left: 5px;
 }
 
 .xdsoft_datetimepicker .xdsoft_next {
-    float: right;
+	float: right;
 	background-position: 0 0;
 }
 
@@ -182,26 +182,26 @@
 }
 
 .xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box >div > div:first-child {
-    border-top-width: 0;
+	border-top-width: 0;
 }
 
 .xdsoft_datetimepicker .xdsoft_today_button:hover,
 .xdsoft_datetimepicker .xdsoft_next:hover,
 .xdsoft_datetimepicker .xdsoft_prev:hover {
-    opacity: 1;
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+	opacity: 1;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 }
 
 .xdsoft_datetimepicker .xdsoft_label {
 	display: inline;
-    position: relative;
-    z-index: 9999;
-    margin: 0;
-    padding: 5px 3px;
-    font-size: 14px;
-    line-height: 20px;
-    font-weight: bold;
-    background-color: #fff;
+	position: relative;
+	z-index: 9999;
+	margin: 0;
+	padding: 5px 3px;
+	font-size: 14px;
+	line-height: 20px;
+	font-weight: bold;
+	background-color: #fff;
 	float: left;
 	width: 182px;
 	text-align: center;
@@ -232,7 +232,7 @@
 .xdsoft_datetimepicker .xdsoft_label > .xdsoft_select.xdsoft_yearselect{ right: 2px }
 .xdsoft_datetimepicker .xdsoft_label > .xdsoft_select > div > .xdsoft_option:hover {
 	color: #fff;
-    background: #ff8000;
+	background: #ff8000;
 }
 
 .xdsoft_datetimepicker .xdsoft_label > .xdsoft_select > div > .xdsoft_option {
@@ -314,7 +314,7 @@
 .xdsoft_datetimepicker .xdsoft_time_box >div >div.xdsoft_disabled {
 	opacity: 0.5;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
-    cursor: default;
+	cursor: default;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_other_month.xdsoft_disabled {
@@ -325,22 +325,22 @@
 .xdsoft_datetimepicker .xdsoft_calendar td:hover,
 .xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box >div >div:hover {
 	color: #fff !important;
-    background: #ff8000 !important;
-    box-shadow: none !important;
+	background: #ff8000 !important;
+	box-shadow: none !important;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_current.xdsoft_disabled:hover,
 .xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box>div>div.xdsoft_current.xdsoft_disabled:hover {
-    background: #33aaff !important;
-    box-shadow: #178fe5 0 1px 3px 0 inset !important;
-    color: #fff !important;
+	background: #33aaff !important;
+	box-shadow: #178fe5 0 1px 3px 0 inset !important;
+	color: #fff !important;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_disabled:hover,
 .xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box >div >div.xdsoft_disabled:hover {
 	color: inherit	!important;
-    background: inherit !important;
-    box-shadow: inherit !important;
+	background: inherit !important;
+	box-shadow: inherit !important;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar th {
@@ -351,11 +351,11 @@
 }
 
 .xdsoft_datetimepicker .xdsoft_copyright {
-    color: #ccc !important;
-    font-size: 10px;
-    clear: both;
-    float: none;
-    margin-left: 8px;
+	color: #ccc !important;
+	font-size: 10px;
+	clear: both;
+	float: none;
+	margin-left: 8px;
 }
 
 .xdsoft_datetimepicker .xdsoft_copyright a { color: #eee !important }
@@ -379,7 +379,7 @@
 	cursor: pointer;
 }
 .xdsoft_scroller_box {
-    position: relative;
+	position: relative;
 }
 
 .xdsoft_datetimepicker.xdsoft_dark {
@@ -402,7 +402,7 @@
 }
 
 .xdsoft_datetimepicker.xdsoft_dark .xdsoft_label {
-    background-color: #000;
+	background-color: #000;
 }
 .xdsoft_datetimepicker.xdsoft_dark .xdsoft_label > .xdsoft_select {
 	border: 1px solid #333;
@@ -411,7 +411,7 @@
 
 .xdsoft_datetimepicker.xdsoft_dark .xdsoft_label > .xdsoft_select > div > .xdsoft_option:hover {
 	color: #000;
-    background: #007fff;
+	background: #007fff;
 }
 
 .xdsoft_datetimepicker.xdsoft_dark .xdsoft_label > .xdsoft_select > div > .xdsoft_option.xdsoft_current {
@@ -453,7 +453,7 @@
 .xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar td:hover,
 .xdsoft_datetimepicker.xdsoft_dark .xdsoft_timepicker .xdsoft_time_box >div >div:hover {
 	color: #000 !important;
-    background: #007fff !important;
+	background: #007fff !important;
 }
 
 .xdsoft_datetimepicker.xdsoft_dark .xdsoft_calendar th {

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1441,7 +1441,12 @@
 							if((options.minDateTime !== false && options.minDateTime > optionDateTime) || (options.maxTime !== false && _xdsoft_datetime.strtotime(options.maxTime).getTime() < now.getTime()) || (options.minTime !== false && _xdsoft_datetime.strtotime(options.minTime).getTime() > now.getTime())) {
 								classes.push('xdsoft_disabled');
 							}
-							if ((options.initTime || options.defaultSelect || datetimepicker.data('changed')) && parseInt(_xdsoft_datetime.currentTime.getHours(), 10) === parseInt(h, 10) && (options.step > 59 || Math[options.roundTime](_xdsoft_datetime.currentTime.getMinutes() / options.step) * options.step === parseInt(m, 10))) {
+
+							var current_time = new Date(_xdsoft_datetime.currentTime);
+							current_time.setHours(parseInt(_xdsoft_datetime.currentTime.getHours(), 10));
+							current_time.setMinutes(Math[options.roundTime](_xdsoft_datetime.currentTime.getMinutes() / options.step) * options.step);
+
+							if ((options.initTime || options.defaultSelect || datetimepicker.data('changed')) && current_time.getHours() === parseInt(h, 10) && (options.step > 59 || current_time.getMinutes() === parseInt(m, 10))) {
 								if (options.defaultSelect || datetimepicker.data('changed')) {
 									classes.push('xdsoft_current');
 								} else if (options.initTime) {

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -824,8 +824,8 @@
 				}
 
 				if (_options.disabledDates && $.isArray(_options.disabledDates) && _options.disabledDates.length) {
-                    options.disabledDates = $.extend(true, [], _options.disabledDates);
-                }
+					options.disabledDates = $.extend(true, [], _options.disabledDates);
+				}
 
 				if ((options.open || options.opened) && (!options.inline)) {
 					input.trigger('open.xdsoft');
@@ -1010,24 +1010,24 @@
 						.off('blur.xdsoft')
 						.on('blur.xdsoft', function () {
 						  if (options.allowBlank && !$.trim($(this).val()).length) {
-						    $(this).val(null);
-						    datetimepicker.data('xdsoft_datetime').empty();
+							$(this).val(null);
+							datetimepicker.data('xdsoft_datetime').empty();
 						  } else if (!Date.parseDate($(this).val(), options.format)) {
-						    var splittedHours   = +([$(this).val()[0], $(this).val()[1]].join('')),
-						        splittedMinutes = +([$(this).val()[2], $(this).val()[3]].join(''));
+							var splittedHours   = +([$(this).val()[0], $(this).val()[1]].join('')),
+								splittedMinutes = +([$(this).val()[2], $(this).val()[3]].join(''));
 
-						    // parse the numbers as 0312 => 03:12
-						    if(!options.datepicker && options.timepicker && splittedHours >= 0 && splittedHours < 24 && splittedMinutes >= 0 && splittedMinutes < 60) {
-						      $(this).val([splittedHours, splittedMinutes].map(function(item) {
-						        return item > 9 ? item : '0' + item
-						      }).join(':'));
-						    } else {
-						      $(this).val((_xdsoft_datetime.now()).dateFormat(options.format));
-						    }
+							// parse the numbers as 0312 => 03:12
+							if(!options.datepicker && options.timepicker && splittedHours >= 0 && splittedHours < 24 && splittedMinutes >= 0 && splittedMinutes < 60) {
+							  $(this).val([splittedHours, splittedMinutes].map(function(item) {
+								return item > 9 ? item : '0' + item
+							  }).join(':'));
+							} else {
+							  $(this).val((_xdsoft_datetime.now()).dateFormat(options.format));
+							}
 
-						    datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
+							datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
 						  } else {
-						    datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
+							datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
 						  }
 
 						  datetimepicker.trigger('changedatetime.xdsoft');
@@ -1842,7 +1842,7 @@
 						datetimepicker.data('xdsoft_datetime').setCurrentTime(this.value);
 						break;
 					case 'validate':
-                        var $input = datetimepicker.data('input');
+						var $input = datetimepicker.data('input');
 						$input.trigger('blur.xdsoft');
 						break;
 					}

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1841,6 +1841,10 @@
 						}
 						datetimepicker.data('xdsoft_datetime').setCurrentTime(this.value);
 						break;
+					case 'validate':
+                        var $input = datetimepicker.data('input');
+						$input.trigger('blur.xdsoft');
+						break;
 					}
 				} else {
 					datetimepicker

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -470,13 +470,15 @@
 		withoutCopyright: true,
 		inverseButton: false,
 		hours12: false,
-		next:	'xdsoft_next',
+		next: 'xdsoft_next',
 		prev : 'xdsoft_prev',
 		dayOfWeekStart: 0,
 		parentID: 'body',
 		timeHeightInTimePicker: 25,
 		timepickerScrollbar: true,
 		todayButton: true,
+		prevButton: true,
+		nextButton: true,
 		defaultSelect: true,
 
 		scrollMonth: true,
@@ -489,6 +491,8 @@
 		allowBlank: true,
 		yearStart: 1950,
 		yearEnd: 2050,
+		monthStart: 0,
+		monthEnd: 11,
 		style: '',
 		id: '',
 		fixed: false,
@@ -879,6 +883,14 @@
 					.find('.xdsoft_today_button')
 						.css('visibility', !options.todayButton ? 'hidden' : 'visible');
 
+				mounth_picker
+					.find('.' + options.prev)
+						.css('visibility', !options.prevButton ? 'hidden' : 'visible');
+
+				mounth_picker
+					.find('.' + options.next)
+						.css('visibility', !options.nextButton ? 'hidden' : 'visible');
+
 				if (options.mask) {
 					var e,
 						getCaretPos = function (input) {
@@ -1003,7 +1015,7 @@
 						  } else if (!Date.parseDate($(this).val(), options.format)) {
 						    var splittedHours   = +([$(this).val()[0], $(this).val()[1]].join('')),
 						        splittedMinutes = +([$(this).val()[2], $(this).val()[3]].join(''));
-						    
+
 						    // parse the numbers as 0312 => 03:12
 						    if(!options.datepicker && options.timepicker && splittedHours >= 0 && splittedHours < 24 && splittedMinutes >= 0 && splittedMinutes < 60) {
 						      $(this).val([splittedHours, splittedMinutes].map(function(item) {
@@ -1012,12 +1024,12 @@
 						    } else {
 						      $(this).val((_xdsoft_datetime.now()).dateFormat(options.format));
 						    }
-						    
+
 						    datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
 						  } else {
 						    datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
 						  }
-						  
+
 						  datetimepicker.trigger('changedatetime.xdsoft');
 						});
 				}
@@ -1469,7 +1481,7 @@
 						yearselect.children().eq(0)
 												.html(opt);
 
-						for (i = 0, opt = ''; i <= 11; i += 1) {
+						for (i = parseInt(options.monthStart), opt = ''; i <= parseInt(options.monthEnd); i += 1) {
 							opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[options.lang].months[i] + '</div>';
 						}
 						monthselect.children().eq(0).html(opt);


### PR DESCRIPTION
- [x] Added option to show/hide previous and next buttons as per today button
   - [x] Added option to set start and end months as per years
- [x] Tidy up - addition of spaces/carriage returns
- [x] Addition of styling to prevent highlighting if hovered over selection is disabled
- [x] Added the ability to call the validate logic from `datetimepicker` similar to reset
- [x] Fix to use tabs over 4 spaces as per rest of repo