### PR TITLE
added min-width property for buttons

### DIFF
--- a/jquery.datetimepicker.css
+++ b/jquery.datetimepicker.css
@@ -143,6 +143,7 @@
 	text-indent: 100%;
 	white-space: nowrap;
 	width: 20px;
+	min-width: 0;
 }
 
 .xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_prev,


### PR DESCRIPTION
If there is a css rule for the `button` element, that has a `min-width` property set, the layout will break. This is fixed by setting the `min-width` back to `0`;