### PR TITLE
Fix dayOfWeek for Indonesian language

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -29,7 +29,7 @@
 					"Januari", "Februari", "Maret", "April", "Mei", "Juni", "Juli", "Agustus", "September", "Oktober", "November", "Desember"
 				],
 				dayOfWeek: [
-					"Sen", "Sel", "Rab", "Kam", "Jum", "Sab", "Min"
+					"Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"
 				]
 			},
 			bg: { // Bulgarian


### PR DESCRIPTION
Fix Indonesian dayOfWeek which previously starts with Monday instead of Sunday. Now it starts with Sunday.