### PR TITLE
Fixed: today button dbl click didn't validate date

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1325,6 +1325,18 @@
 					_xdsoft_datetime.setCurrentTime(0);
 					datetimepicker.trigger('afterOpen.xdsoft');
 				}).on('dblclick.xdsoft', function () {
+					var currentDate = _xdsoft_datetime.getCurrentTime();
+					currentDate = new Date(currentDate.getFullYear(),currentDate.getMonth(),currentDate.getDate());
+					var minDate = _xdsoft_datetime.strtodate(options.minDate);
+					minDate = new Date(minDate.getFullYear(),minDate.getMonth(),minDate.getDate());
+					if(currentDate < minDate) {
+						return;
+					}
+					var maxDate = _xdsoft_datetime.strtodate(options.maxDate);
+					maxDate = new Date(maxDate.getFullYear(),maxDate.getMonth(),maxDate.getDate());
+					if(currentDate > maxDate) {
+						return;
+					}
 					input.val(_xdsoft_datetime.str());
 					datetimepicker.trigger('close.xdsoft');
 				});


### PR DESCRIPTION
The today (home) button shows the current month. After the double click it selected the current date and closed the popup, not validating the current date against the specified minimum and maximum dates.

Now, if the current date is out of the allowed range, the popup stays visible, and the input value is not changed.