### PR TITLE
Fixed parent positioning bug

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1788,6 +1788,14 @@
 						left = $(window).width() - datetimepicker[0].offsetWidth;
 					}
 				}
+				var node = datetimepicker[0]
+				do {
+					node = node.parentNode;
+					if(window.getComputedStyle(node).getPropertyValue('position') === 'relative' && $(window).width() >= node.offsetWidth) {
+						left = left - (($(window).width() - node.offsetWidth)/2)
+						break
+					}
+				} while(node.nodeName != 'HTML')
 				datetimepicker.css({
 					left: left,
 					top: top,


### PR DESCRIPTION
Datetimepicker positions itself as the last child inside the body tag.
If either of its parents (body and html tags) have CSS position property with value 'relative' and is smaller than the browser window size, the left-position will be incorrect.

For demonstration check out:
http://legitsoft.org/datepicker/

First open the datetimepicker by clicking the input field, then change the width of the browser window from small to normal to wide. Click the fix button and do the same again.