### PR TITLE
Fix: the popup should be closed on date-click if timepicker is disabled

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1669,7 +1669,7 @@
 					datetimepicker.trigger('select.xdsoft', [currentTime]);
 
 					input.val(_xdsoft_datetime.str());
-					if ((timerclick > 1 || (options.closeOnDateSelect === true || (options.closeOnDateSelect === 0 && !options.timepicker))) && !options.inline) {
+					if ((timerclick > 1 || (options.closeOnDateSelect === true || (options.closeOnDateSelect === false && !options.timepicker))) && !options.inline) {
 						datetimepicker.trigger('close.xdsoft');
 					}
 


### PR DESCRIPTION
When "timepicker" is disabled - the popup should close on date-click. The "if" was failing because of the type diff