### PR TITLE
Add license information to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,50 +1,52 @@
 {
-	"name":"datetimepicker",
-	"version":"2.4.3",
-	"main": [
-		"jquery.datetimepicker.js",
-		"jquery.datetimepicker.css"
-	],
-	"ignore": [
-		"**/screen",
-		"**/datetimepicker.jquery.json",
-		"**/*.png",
-		"**/*.txt",
-		"**/*.md",
-		"**/*.html",
-		"**/*.tpl",
-		"**/jquery.js"
-	  ],
-	"keywords": [
-		"calendar",
-		"date",
-		"time",
-		"form",
-		"datetime",
-		"datepicker",
-		"timepicker",
-		"datetimepicker",
-		"validation",
-		"ui",
-		"scroller",
-		"picker",
-		"i18n",
-		"input",
-		"jquery",
-		"touch"
-	],
-	"dependencies": {
+  "name": "datetimepicker",
+  "version": "2.4.3",
+  "main": [
+    "jquery.datetimepicker.js",
+    "jquery.datetimepicker.css"
+  ],
+  "ignore": [
+    "**/screen",
+    "**/datetimepicker.jquery.json",
+    "**/*.png",
+    "**/*.txt",
+    "**/*.md",
+    "**/*.html",
+    "**/*.tpl",
+    "**/jquery.js"
+  ],
+  "keywords": [
+    "calendar",
+    "date",
+    "time",
+    "form",
+    "datetime",
+    "datepicker",
+    "timepicker",
+    "datetimepicker",
+    "validation",
+    "ui",
+    "scroller",
+    "picker",
+    "i18n",
+    "input",
+    "jquery",
+    "touch"
+  ],
+  "dependencies": {
     "jquery": ">= 1.7.2"
   },
-	"authors": [
-		{
-			"name": 	"Chupurnov Valeriy",
-			"email": 	"chupurnov@gmail.com",
-			"homepage": 		"http://xdsoft.net/contacts.html"
+  "authors": [
+    {
+      "name": "Chupurnov Valeriy",
+      "email": "chupurnov@gmail.com",
+      "homepage": "http://xdsoft.net/contacts.html"
     }
-	],
-	"homepage":"http://xdsoft.net/jqplugins/datetimepicker/",
-	"repository": {
-		"type": "git", "url": "git://github.com:xdan/datetimepicker.git"
-	}
+  ],
+  "license": "MIT",
+  "homepage": "http://xdsoft.net/jqplugins/datetimepicker/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com:xdan/datetimepicker.git"
+  }
 }


### PR DESCRIPTION
The licensing information is useful for different automated tools,
including WebJars.org.  WebJars.org will not build and host a WebJar
for a project for which it cannot determine licensing.  It first looks
for licensing information in bower.json, but will attempt to determine
the license by looking at certain files (e.g., "LICENSE").
Unfortunately, datetimepicker's license file doesn't have a "standard"
name.  Also, I should mention that NPM is missing versions 2.4.1-2.4.3,
so an up-to-date version of datetimepicker cannot be built from NPM
using WebJars.org.