### PR TITLE
Allow maxDate in past or minDate in future

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1026,11 +1026,11 @@
 					timeboxparent.xdsoftScroller('hide');
 				}
 
-				if (options.minDate && /^-(.*)$/.test(options.minDate)) {
+				if (options.minDate && /^[\+\-](.*)$/.test(options.minDate)) {
 					options.minDate = _xdsoft_datetime.strToDateTime(options.minDate).dateFormat(options.formatDate);
 				}
 
-				if (options.maxDate &&  /^\+(.*)$/.test(options.maxDate)) {
+				if (options.maxDate &&  /^[\+\-](.*)$/.test(options.maxDate)) {
 					options.maxDate = _xdsoft_datetime.strToDateTime(options.maxDate).dateFormat(options.formatDate);
 				}
 


### PR DESCRIPTION
Beforehand the maxDate was only allowed to be the current date (+1970/01/01) or a date in the future (e.g. +1970/01/10). You couldn't set the maxDate to yesterday (e.g. -1970/01/02) or earlier in a logical manner.

All the functionality is in there, just needed the regex opened up to check for a plus or a minus at the start of the maxDate and minDate variables and parse them if present.