### PR TITLE
double-click on today button does not trigger change event

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1388,6 +1388,7 @@
 						return;
 					}
 					input.val(_xdsoft_datetime.str());
+					input.trigger('change');
 					datetimepicker.trigger('close.xdsoft');
 				});
 			mounth_picker


### PR DESCRIPTION
Double-clicking on the "today button", which changes the value of the input to the current date and time, does not trigger a change event on the input. Manually selecting a date or a time does trigger a change event on the input. Proposed edit ensures that a change event is also triggered on the input when one double-clicks on the "today button".