### PR TITLE
Date format. Support i18n + D, l, M, F php style format characters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,16 @@
 	<h3>Dark theme</h3>
 	<p>thank for this <a href="https://github.com/lampslave">https://github.com/lampslave</a></p>
 	<input type="text" id="datetimepicker_dark"/>
-	<h3>Date time format</h3>
+	<h3>Date time format and locale</h3>
 	<p></p>
+	<select id="datetimepicker_format_locale">
+		<option value="en">English</option>
+		<option value="de">German</option>
+		<option value="ru">Russian</option>
+		<option value="uk">Ukrainian</option>
+		<option value="fr">French</option>
+		<option value="es">Spanish</option>
+	</select>
 	<input type="text" value="D, l, M, F, Y-m-d H:i:s" id="datetimepicker_format_value"/>
 	<input type="button" value="applay =>" id="datetimepicker_format_change"/>
 	<input type="text" id="datetimepicker_format" class="input input-wide"/>
@@ -81,6 +89,9 @@ $.datetimepicker.setLocale('en');
 $('#datetimepicker_format').datetimepicker({value:'2015/04/15 05:03', format: $("#datetimepicker_format_value").val()});
 $("#datetimepicker_format_change").on("click", function(e){
 	$("#datetimepicker_format").data('xdsoft_datetimepicker').setOptions({format: $("#datetimepicker_format_value").val()});
+});
+$("#datetimepicker_format_locale").on("change", function(e){
+	$.datetimepicker.setLocale($(e.currentTarget).val());
 });
 
 $('#datetimepicker').datetimepicker({

--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
 	background-color: red !important;
 }
 
+.input{	
+}
+.input-wide{
+	width: 500px;
+}
+
 </style>
 </head>
 <body>
@@ -57,6 +63,11 @@
 	<h3>Dark theme</h3>
 	<p>thank for this <a href="https://github.com/lampslave">https://github.com/lampslave</a></p>
 	<input type="text" id="datetimepicker_dark"/>
+	<h3>Date time format</h3>
+	<p></p>
+	<input type="text" value="D, l, M, F, Y-m-d H:i:s" id="datetimepicker_format_value"/>
+	<input type="button" value="applay =>" id="datetimepicker_format_change"/>
+	<input type="text" id="datetimepicker_format" class="input input-wide"/>
 </body>
 <script src="./jquery.js"></script>
 <script src="./jquery.datetimepicker.js"></script>
@@ -64,6 +75,14 @@
 window.onerror = function(errorMsg) {
 	$('#console').html($('#console').html()+'<br>'+errorMsg)
 }*/
+
+$.datetimepicker.setLocale('en');
+
+$('#datetimepicker_format').datetimepicker({value:'2015/04/15 05:03', format: $("#datetimepicker_format_value").val()});
+$("#datetimepicker_format_change").on("click", function(e){
+	$("#datetimepicker_format").data('xdsoft_datetimepicker').setOptions({format: $("#datetimepicker_format_value").val()});
+});
+
 $('#datetimepicker').datetimepicker({
 dayOfWeekStart : 1,
 lang:'en',

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -12,151 +12,169 @@
 				months: [
 					"كانون الثاني", "شباط", "آذار", "نيسان", "مايو", "حزيران", "تموز", "آب", "أيلول", "تشرين الأول", "تشرين الثاني", "كانون الأول"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"ن", "ث", "ع", "خ", "ج", "س", "ح"
-				]
+				],
+				dayOfWeek: ["الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت", "الأحد"]
 			},
 			ro: { // Romanian
 				months: [
-					"ianuarie", "februarie", "martie", "aprilie", "mai", "iunie", "iulie", "august", "septembrie", "octombrie", "noiembrie", "decembrie"
+					"Ianuarie", "Februarie", "Martie", "Aprilie", "Mai", "Iunie", "Iulie", "August", "Septembrie", "Octombrie", "Noiembrie", "Decembrie"
 				],
-				dayOfWeek: [
-					"l", "ma", "mi", "j", "v", "s", "d"
-				]
+				dayOfWeekShort: [
+					"Du", "Lu", "Ma", "Mi", "Jo", "Vi", "Sâ"
+				],
+				dayOfWeek: ["Duminică", "Luni", "Marţi", "Miercuri", "Joi", "Vineri", "Sâmbătă"]
 			},
 			id: { // Indonesian
 				months: [
 					"Januari", "Februari", "Maret", "April", "Mei", "Juni", "Juli", "Agustus", "September", "Oktober", "November", "Desember"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"
-				]
+				],
+				dayOfWeek: ["Minggu", "Senin", "Selasa", "Rabu", "Kamis", "Jumat", "Sabtu"]
 			},
 			is: { // Icelandic
 				months: [
 					"Janúar", "Febrúar", "Mars", "Apríl", "Maí", "Júní", "Júlí", "Ágúst", "September", "Október", "Nóvember", "Desember"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Sun", "Mán", "Þrið", "Mið", "Fim", "Fös", "Lau"
-				]
+				],
+				dayOfWeek: ["Sunnudagur", "Mánudagur", "Þriðjudagur", "Miðvikudagur", "Fimmtudagur", "Föstudagur", "Laugardagur"]
 			},
 			bg: { // Bulgarian
 				months: [
 					"Януари", "Февруари", "Март", "Април", "Май", "Юни", "Юли", "Август", "Септември", "Октомври", "Ноември", "Декември"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
-				]
+				],
+				dayOfWeek: ["Неделя", "Понеделник", "Вторник", "Сряда", "Четвъртък", "Петък", "Събота"]
 			},
 			fa: { // Persian/Farsi
 				months: [
 					'فروردین', 'اردیبهشت', 'خرداد', 'تیر', 'مرداد', 'شهریور', 'مهر', 'آبان', 'آذر', 'دی', 'بهمن', 'اسفند'
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					'یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه'
-				]
+				],
+				dayOfWeek: ["یک‌شنبه", "دوشنبه", "سه‌شنبه", "چهارشنبه", "پنج‌شنبه", "جمعه", "شنبه", "یک‌شنبه"]
 			},
 			ru: { // Russian
 				months: [
 					'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь', 'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь'
 				],
-				dayOfWeek: [
-					"Вск", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
-				]
+				dayOfWeekShort: [
+					"Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
+				],
+				dayOfWeek: ["Воскресенье", "Понедельник", "Вторник", "Среда", "Четверг", "Пятница", "Суббота"]
 			},
 			uk: { // Ukrainian
 				months: [
 					'Січень', 'Лютий', 'Березень', 'Квітень', 'Травень', 'Червень', 'Липень', 'Серпень', 'Вересень', 'Жовтень', 'Листопад', 'Грудень'
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Ндл", "Пнд", "Втр", "Срд", "Чтв", "Птн", "Сбт"
-				]
+				],
+				dayOfWeek: ["Неділя", "Понеділок", "Вівторок", "Середа", "Четвер", "П'ятниця", "Субота"]
 			},
 			en: { // English
 				months: [
 					"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-				]
+				],
+				dayOfWeek: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 			},
 			el: { // Ελληνικά
 				months: [
 					"Ιανουάριος", "Φεβρουάριος", "Μάρτιος", "Απρίλιος", "Μάιος", "Ιούνιος", "Ιούλιος", "Αύγουστος", "Σεπτέμβριος", "Οκτώβριος", "Νοέμβριος", "Δεκέμβριος"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Κυρ", "Δευ", "Τρι", "Τετ", "Πεμ", "Παρ", "Σαβ"
-				]
+				],
+				dayOfWeek: ["Κυριακή", "Δευτέρα", "Τρίτη", "Τετάρτη", "Πέμπτη", "Παρασκευή", "Σάββατο"]
 			},
 			de: { // German
 				months: [
 					'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"
-				]
+				],
+				dayOfWeek: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"]
 			},
 			nl: { // Dutch
 				months: [
 					"januari", "februari", "maart", "april", "mei", "juni", "juli", "augustus", "september", "oktober", "november", "december"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"zo", "ma", "di", "wo", "do", "vr", "za"
-				]
+				],
+				dayOfWeek: ["zondag", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag"]
 			},
 			tr: { // Turkish
 				months: [
 					"Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim", "Kasım", "Aralık"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Paz", "Pts", "Sal", "Çar", "Per", "Cum", "Cts"
-				]
+				],
+				dayOfWeek: ["Pazar", "Pazartesi", "Salı", "Çarşamba", "Perşembe", "Cuma", "Cumartesi"]
 			},
 			fr: { //French
 				months: [
 					"Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"
-				]
+				],
+				dayOfWeek: ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"]
 			},
 			es: { // Spanish
 				months: [
 					"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"
-				]
+				],
+				dayOfWeek: ["Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"]
 			},
 			th: { // Thai
 				months: [
 					'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					'อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'
-				]
+				],
+				dayOfWeek: ["อาทิตย์", "จันทร์", "อังคาร", "พุธ", "พฤหัส", "ศุกร์", "เสาร์", "อาทิตย์"]
 			},
 			pl: { // Polish
 				months: [
 					"styczeń", "luty", "marzec", "kwiecień", "maj", "czerwiec", "lipiec", "sierpień", "wrzesień", "październik", "listopad", "grudzień"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"nd", "pn", "wt", "śr", "cz", "pt", "sb"
-				]
+				],
+				dayOfWeek: ["niedziela", "poniedziałek", "wtorek", "środa", "czwartek", "piątek", "sobota"]
 			},
 			pt: { // Portuguese
 				months: [
 					"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"
-				]
+				],
+				dayOfWeek: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"]
 			},
 			ch: { // Simplified Chinese
 				months: [
 					"一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"日", "一", "二", "三", "四", "五", "六"
 				]
 			},
@@ -164,7 +182,7 @@
 				months: [
 					"Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September",  "Oktober", "November", "December"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
 				]
 			},
@@ -172,63 +190,70 @@
 				months: [
 					"1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"일", "월", "화", "수", "목", "금", "토"
-				]
+				],
+				dayOfWeek: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
 			},
 			it: { // Italian
 				months: [
 					"Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab"
-				]
+				],
+				dayOfWeek: ["Domenica", "Lunedì", "Martedì", "Mercoledì", "Giovedì", "Venerdì", "Sabato"]
 			},
 			da: { // Dansk
 				months: [
 					"January", "Februar", "Marts", "April", "Maj", "Juni", "July", "August", "September", "Oktober", "November", "December"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
-				]
+				],
+				dayOfWeek: ["søndag", "mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag"]
 			},
 			no: { // Norwegian
 				months: [
 					"Januar", "Februar", "Mars", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Desember"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
-				]
+				],
+				dayOfWeek: ['Søndag', 'Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lørdag']
 			},
 			ja: { // Japanese
 				months: [
 					"1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"日", "月", "火", "水", "木", "金", "土"
-				]
+				],
+				dayOfWeek: ["日曜", "月曜", "火曜", "水曜", "木曜", "金曜", "土曜"]
 			},
 			vi: { // Vietnamese
 				months: [
 					"Tháng 1", "Tháng 2", "Tháng 3", "Tháng 4", "Tháng 5", "Tháng 6", "Tháng 7", "Tháng 8", "Tháng 9", "Tháng 10", "Tháng 11", "Tháng 12"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"CN", "T2", "T3", "T4", "T5", "T6", "T7"
-				]
+				],
+				dayOfWeek: ["Chủ nhật", "Thứ hai", "Thứ ba", "Thứ tư", "Thứ năm", "Thứ sáu", "Thứ bảy"]
 			},
 			sl: { // Slovenščina
 				months: [
 					"Januar", "Februar", "Marec", "April", "Maj", "Junij", "Julij", "Avgust", "September", "Oktober", "November", "December"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Ned", "Pon", "Tor", "Sre", "Čet", "Pet", "Sob"
-				]
+				],
+				dayOfWeek: ["Nedelja", "Ponedeljek", "Torek", "Sreda", "Četrtek", "Petek", "Sobota"]
 			},
 			cs: { // Čeština
 				months: [
 					"Leden", "Únor", "Březen", "Duben", "Květen", "Červen", "Červenec", "Srpen", "Září", "Říjen", "Listopad", "Prosinec"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Ne", "Po", "Út", "St", "Čt", "Pá", "So"
 				]
 			},
@@ -236,213 +261,240 @@
 				months: [
 					"Január", "Február", "Március", "Április", "Május", "Június", "Július", "Augusztus", "Szeptember", "Október", "November", "December"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Va", "Hé", "Ke", "Sze", "Cs", "Pé", "Szo"
-				]
+				],
+				dayOfWeek: ["vasárnap", "hétfő", "kedd", "szerda", "csütörtök", "péntek", "szombat"]
 			},
 			az: { //Azerbaijanian (Azeri)
 				months: [
 					"Yanvar", "Fevral", "Mart", "Aprel", "May", "Iyun", "Iyul", "Avqust", "Sentyabr", "Oktyabr", "Noyabr", "Dekabr"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"B", "Be", "Ça", "Ç", "Ca", "C", "Ş"
-				]
+				],
+				dayOfWeek: ["Bazar", "Bazar ertəsi", "Çərşənbə axşamı", "Çərşənbə", "Cümə axşamı", "Cümə", "Şənbə"]
 			},
 			bs: { //Bosanski
 				months: [
 					"Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
-				]
+				],
+				dayOfWeek: ["Nedjelja","Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota"]
 			},
 			ca: { //Català
 				months: [
 					"Gener", "Febrer", "Març", "Abril", "Maig", "Juny", "Juliol", "Agost", "Setembre", "Octubre", "Novembre", "Desembre"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Dg", "Dl", "Dt", "Dc", "Dj", "Dv", "Ds"
-				]
+				],
+				dayOfWeek: ["Diumenge", "Dilluns", "Dimarts", "Dimecres", "Dijous", "Divendres", "Dissabte"]
 			},
 			'en-GB': { //English (British)
 				months: [
 					"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-				]
+				],
+				dayOfWeek: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 			},
 			et: { //"Eesti"
 				months: [
 					"Jaanuar", "Veebruar", "Märts", "Aprill", "Mai", "Juuni", "Juuli", "August", "September", "Oktoober", "November", "Detsember"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"P", "E", "T", "K", "N", "R", "L"
-				]
+				],
+				dayOfWeek: ["Pühapäev", "Esmaspäev", "Teisipäev", "Kolmapäev", "Neljapäev", "Reede", "Laupäev"]
 			},
 			eu: { //Euskara
 				months: [
 					"Urtarrila", "Otsaila", "Martxoa", "Apirila", "Maiatza", "Ekaina", "Uztaila", "Abuztua", "Iraila", "Urria", "Azaroa", "Abendua"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Ig.", "Al.", "Ar.", "Az.", "Og.", "Or.", "La."
-				]
+				],
+				dayOfWeek: ['Igandea', 'Astelehena', 'Asteartea', 'Asteazkena', 'Osteguna', 'Ostirala', 'Larunbata']
 			},
 			fi: { //Finnish (Suomi)
 				months: [
 					"Tammikuu", "Helmikuu", "Maaliskuu", "Huhtikuu", "Toukokuu", "Kesäkuu", "Heinäkuu", "Elokuu", "Syyskuu", "Lokakuu", "Marraskuu", "Joulukuu"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Su", "Ma", "Ti", "Ke", "To", "Pe", "La"
-				]
+				],
+				dayOfWeek: ["sunnuntai", "maanantai", "tiistai", "keskiviikko", "torstai", "perjantai", "lauantai"]
 			},
 			gl: { //Galego
 				months: [
 					"Xan", "Feb", "Maz", "Abr", "Mai", "Xun", "Xul", "Ago", "Set", "Out", "Nov", "Dec"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Dom", "Lun", "Mar", "Mer", "Xov", "Ven", "Sab"
-				]
+				],
+				dayOfWeek: ["Domingo", "Luns", "Martes", "Mércores", "Xoves", "Venres", "Sábado"]
 			},
 			hr: { //Hrvatski
 				months: [
 					"Siječanj", "Veljača", "Ožujak", "Travanj", "Svibanj", "Lipanj", "Srpanj", "Kolovoz", "Rujan", "Listopad", "Studeni", "Prosinac"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
-				]
+				],
+				dayOfWeek: ["Nedjelja", "Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota"]
 			},
 			ko: { //Korean (한국어)
 				months: [
 					"1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"일", "월", "화", "수", "목", "금", "토"
-				]
+				],
+				dayOfWeek: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
 			},
 			lt: { //Lithuanian (lietuvių)
 				months: [
 					"Sausio", "Vasario", "Kovo", "Balandžio", "Gegužės", "Birželio", "Liepos", "Rugpjūčio", "Rugsėjo", "Spalio", "Lapkričio", "Gruodžio"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Sek", "Pir", "Ant", "Tre", "Ket", "Pen", "Šeš"
-				]
+				],
+				dayOfWeek: ["Sekmadienis", "Pirmadienis", "Antradienis", "Trečiadienis", "Ketvirtadienis", "Penktadienis", "Šeštadienis"]
 			},
 			lv: { //Latvian (Latviešu)
 				months: [
 					"Janvāris", "Februāris", "Marts", "Aprīlis ", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Decembris"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Sv", "Pr", "Ot", "Tr", "Ct", "Pk", "St"
-				]
+				],
+				dayOfWeek: ["Svētdiena", "Pirmdiena", "Otrdiena", "Trešdiena", "Ceturtdiena", "Piektdiena", "Sestdiena"]
 			},
 			mk: { //Macedonian (Македонски)
 				months: [
 					"јануари", "февруари", "март", "април", "мај", "јуни", "јули", "август", "септември", "октомври", "ноември", "декември"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"нед", "пон", "вто", "сре", "чет", "пет", "саб"
-				]
+				],
+				dayOfWeek: ["Недела", "Понеделник", "Вторник", "Среда", "Четврток", "Петок", "Сабота"]
 			},
 			mn: { //Mongolian (Монгол)
 				months: [
 					"1-р сар", "2-р сар", "3-р сар", "4-р сар", "5-р сар", "6-р сар", "7-р сар", "8-р сар", "9-р сар", "10-р сар", "11-р сар", "12-р сар"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Дав", "Мяг", "Лха", "Пүр", "Бсн", "Бям", "Ням"
-				]
+				],
+				dayOfWeek: ["Даваа", "Мягмар", "Лхагва", "Пүрэв", "Баасан", "Бямба", "Ням"]
 			},
 			'pt-BR': { //Português(Brasil)
 				months: [
 					"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"
-				]
+				],
+				dayOfWeek: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"]
 			},
 			sk: { //Slovenčina
 				months: [
 					"Január", "Február", "Marec", "Apríl", "Máj", "Jún", "Júl", "August", "September", "Október", "November", "December"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Ne", "Po", "Ut", "St", "Št", "Pi", "So"
-				]
+				],
+				dayOfWeek: ["Nedeľa", "Pondelok", "Utorok", "Streda", "Štvrtok", "Piatok", "Sobota"]
 			},
 			sq: { //Albanian (Shqip)
 				months: [
-					"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
+					"Janar", "Shkurt", "Mars", "Prill", "Maj", "Qershor", "Korrik", "Gusht", "Shtator", "Tetor", "Nëntor", "Dhjetor"
 				],
-				dayOfWeek: [
-					"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-				]
+				dayOfWeekShort: [
+					"Die", "Hën", "Mar", "Mër", "Enj", "Pre", "Shtu"
+				],
+				dayOfWeek: ["E Diel", "E Hënë", "E Martē", "E Mërkurë", "E Enjte", "E Premte", "E Shtunë"]
 			},
 			'sr-YU': { //Serbian (Srpski)
 				months: [
 					"Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Ned", "Pon", "Uto", "Sre", "čet", "Pet", "Sub"
-				]
+				],
+				dayOfWeek: ["Nedelja","Ponedeljak", "Utorak", "Sreda", "Četvrtak", "Petak", "Subota"]
 			},
 			sr: { //Serbian Cyrillic (Српски)
 				months: [
 					"јануар", "фебруар", "март", "април", "мај", "јун", "јул", "август", "септембар", "октобар", "новембар", "децембар"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"нед", "пон", "уто", "сре", "чет", "пет", "суб"
-				]
+				],
+				dayOfWeek: ["Недеља","Понедељак", "Уторак", "Среда", "Четвртак", "Петак", "Субота"]
 			},
 			sv: { //Svenska
 				months: [
 					"Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September", "Oktober", "November", "December"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
-				]
+				],
+				dayOfWeek: ["Söndag", "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag"]
 			},
 			'zh-TW': { //Traditional Chinese (繁體中文)
 				months: [
 					"一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"日", "一", "二", "三", "四", "五", "六"
-				]
+				],
+				dayOfWeek: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
 			},
 			zh: { //Simplified Chinese (简体中文)
 				months: [
 					"一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"日", "一", "二", "三", "四", "五", "六"
-				]
+				],
+				dayOfWeek: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
 			},
 			he: { //Hebrew (עברית)
 				months: [
 					'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					'א\'', 'ב\'', 'ג\'', 'ד\'', 'ה\'', 'ו\'', 'שבת'
-				]
+				],
+				dayOfWeek: ["ראשון", "שני", "שלישי", "רביעי", "חמישי", "שישי", "שבת", "ראשון"]
 			},
 			hy: { // Armenian
 				months: [
 					"Հունվար", "Փետրվար", "Մարտ", "Ապրիլ", "Մայիս", "Հունիս", "Հուլիս", "Օգոստոս", "Սեպտեմբեր", "Հոկտեմբեր", "Նոյեմբեր", "Դեկտեմբեր"
 				],
-				dayOfWeek: [
+				dayOfWeekShort: [
 					"Կի", "Երկ", "Երք", "Չոր", "Հնգ", "Ուրբ", "Շբթ"
-				]
+				],
+				dayOfWeek: ["Կիրակի", "Երկուշաբթի", "Երեքշաբթի", "Չորեքշաբթի", "Հինգշաբթի", "Ուրբաթ", "Շաբաթ"]
 			},
             kg: { // Kyrgyz
                 months: [
                     'Үчтүн айы', 'Бирдин айы', 'Жалган Куран', 'Чын Куран', 'Бугу', 'Кулжа', 'Теке', 'Баш Оона', 'Аяк Оона', 'Тогуздун айы', 'Жетинин айы', 'Бештин айы'
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Жек", "Дүй", "Шей", "Шар", "Бей", "Жум", "Ише"
+                ],
+				dayOfWeek: [
+                    "Жекшемб", "Дүйшөмб", "Шейшемб", "Шаршемб", "Бейшемби", "Жума", "Ишенб"
                 ]
             }
 		},
 		value: '',
-		lang: 'en',
 		rtl: false,
 
 		format:	'Y/m/d H:i',
@@ -529,6 +581,19 @@
 		enterLikeTab: true,
         showApplyButton: false
 	};
+	
+	var globalLocaleDefault = 'en',
+		globalLocale = 'en';
+	// for locale settings
+	$.datetimepicker = {
+		setLocale: function(locale){
+			globalLocale = default_options.i18n[locale]?locale:globalLocaleDefault;
+			// Override Parse and Format Library entities
+			Date.monthNames = default_options.i18n[globalLocale].months;
+			Date.dayNames = default_options.i18n[globalLocale].dayOfWeek;
+		}
+	};
+	
 	// fix for ie8
 	if (!window.getComputedStyle) {
 		window.getComputedStyle = function (el, pseudo) {
@@ -716,7 +781,7 @@
 			timeboxparent.trigger('resize_scroll.xdsoft_scroller', [percent]);
 		});
 	};
-
+	
 	$.fn.datetimepicker = function (opt) {
 		var KEY0 = 48,
 			KEY9 = 57,
@@ -876,7 +941,7 @@
 					}
 				});
 
-			datetimepicker.setOptions = function (_options) {
+			datetimepicker.setOptions = function (_options) {			
 				var highlightedDates = {},
 					getCaretPos = function (input) {
 						try {
@@ -1503,7 +1568,7 @@
 						}
 
 						for (j = 0; j < 7; j += 1) {
-							table += '<th>' + options.i18n[options.lang].dayOfWeek[(j + options.dayOfWeekStart) % 7] + '</th>';
+							table += '<th>' + options.i18n[globalLocale].dayOfWeekShort[(j + options.dayOfWeekStart) % 7] + '</th>';
 						}
 
 						table += '</tr></thead>';
@@ -1599,7 +1664,7 @@
 
 						calendar.html(table);
 
-						mounth_picker.find('.xdsoft_label span').eq(0).text(options.i18n[options.lang].months[_xdsoft_datetime.currentTime.getMonth()]);
+						mounth_picker.find('.xdsoft_label span').eq(0).text(options.i18n[globalLocale].months[_xdsoft_datetime.currentTime.getMonth()]);
 						mounth_picker.find('.xdsoft_label span').eq(1).text(_xdsoft_datetime.currentTime.getFullYear());
 
 						// generate timebox
@@ -1668,7 +1733,7 @@
 												.html(opt);
 
 						for (i = parseInt(options.monthStart, 10), opt = ''; i <= parseInt(options.monthEnd, 10); i += 1) {
-							opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[options.lang].months[i] + '</div>';
+							opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[globalLocale].months[i] + '</div>';
 						}
 						monthselect.children().eq(0).html(opt);
 						$(datetimepicker)


### PR DESCRIPTION
Formatting date only works with the English language. I like PHP style format and i need to get a form with the full name of the month and day of the week. Date-functions library (Baron Schwartz) does not support i18n and uses the name of the day and the month added to date (only English).
This is my solution. I propose to declare the language (locale) for all the widgets on the page, and set the constant values for the Date.

Like this: 
```javascript
$.datetimepicker.setLocale('en');
```

SetLocale changes Date language constants:
```javascript
Date.monthNames = default_options.i18n[globalLocale].months;
Date.dayNames = default_options.i18n[globalLocale].dayOfWeek;
```

P.S. Option 'lang' for every widget is now removed.