### PR TITLE
Add forgotten amd date-functions requirement

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -7,7 +7,7 @@
 ;(function (factory) {
 	if ( typeof define === 'function' && define.amd ) {
 		// AMD. Register as an anonymous module.
-		define(['jquery', 'jquery-mousewheel'], factory);
+		define(['jquery', 'jquery-mousewheel', 'date-functions'], factory);
 	} else if (typeof exports === 'object') {
 		// Node/CommonJS style for Browserify
 		module.exports = factory;


### PR DESCRIPTION
Really sorry about this one: forgot to add the date-functions requirement in amd definition.

Also when can we expect a new bower version please ?

Thanks for your time.

