### PR TITLE
setLocale in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-datetimepicker
+# datetimepicker
 ==============
+
+**!!! The latest version of the options 'lang' obsolete. The language setting is now global. !!!**
+
+Use this:
+```javascript
+$.datetimepicker.setLocale('en');
+```
 [Documentation][doc]
 
 


### PR DESCRIPTION
Users using the 'lang' option seems unhappy. Maybe it was a mistake). I added a small warning in the documentation. It would be good to move the documentation into githab or update.