### PR TITLE
Fix caret position when lazyInit and mask is set to true.

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1156,6 +1156,7 @@
 					if ($.type(options.mask) === 'string') {
 						if (!isValidValue(options.mask, input.val())) {
 							input.val(options.mask.replace(/[0-9]/g, '_'));
+							setCaretPos(input[0], 0);
 						}
 
 						input.on('keydown.xdsoft', function (event) {


### PR DESCRIPTION
Currently when lazyInit and mask is set to true, caret position will be set at the end. This makes it unable to type the date unless we move the cursor back to the start. 

I am not exactly sure if this is the correct place or way to do it but it works as expected.