### PR TITLE
Fixed "tablike"-behavior to include button- and a-Tags

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -2050,7 +2050,7 @@
 					var val = this.value, elementSelector,
 						key = event.which;
 					if ([ENTER].indexOf(key) !== -1 && options.enterLikeTab) {
-						elementSelector = $("input:visible,textarea:visible");
+						elementSelector = $("input:visible,textarea:visible,button:visible,a:visible");
 						datetimepicker.trigger('close.xdsoft');
 						elementSelector.eq(elementSelector.index(this) + 1).focus();
 						return false;


### PR DESCRIPTION
I just encountered an issue with the behaviour of "enterLikeTab". The feature didn't include button- and a-Tags which is a difference to all of my browsers.

I added these elements to the selector to behave like the real browser now.