### PR TITLE
Bug fixed - The datetimepicker will overflow-y

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1986,7 +1986,26 @@
 			current_time_index = 0;
 
 			setPos = function () {
-				var offset = datetimepicker.data('input').offset(), datetimepickerelement = datetimepicker.data('input')[0], top = offset.top + datetimepickerelement.offsetHeight - 1, left = offset.left, position = "absolute", node;
+				/**
+                 * 修复输入框在window最右边，且输入框的宽度小于日期控件宽度情况下，日期控件显示不全的bug。
+                 * Bug fixed - The datetimepicker will overflow-y when the width of the date input less than its, which
+                 * could causes part of the datetimepicker being hidden.
+                 * by Soon start
+                 */
+                var offset = datetimepicker.data('input').offset(),
+                    datetimepickerelement = datetimepicker.data('input')[0],
+                    top = offset.top + datetimepickerelement.offsetHeight - 1,
+                    left = offset.left,
+                    position = "absolute",
+                    node;
+
+                if ((document.documentElement.clientWidth - offset.left) < datepicker.parent().outerWidth(true)) {
+                    var diff = datepicker.parent().outerWidth(true) - datetimepickerelement.offsetWidth;
+                    left = left - diff;
+                }
+                /**
+                 * by Soon end
+                 */
 				if (datetimepicker.data('input').parent().css('direction') == 'rtl')
 					left -= (datetimepicker.outerWidth() - datetimepicker.data('input').outerWidth());
 				if (options.fixed) {


### PR DESCRIPTION
### **Bug fixed - The datetimepicker will overflow-y when the width of the date input less than its, which could causes part of the datetimepicker being hidden.**

> **Before:**
![qq 20160201180534](https://cloud.githubusercontent.com/assets/7589350/12714591/95ed9864-c910-11e5-9fde-6c1040c5bb99.jpg)

> **After:**
![qq 20160201181901](https://cloud.githubusercontent.com/assets/7589350/12714592/95f32612-c910-11e5-8291-da9e3e54d9d5.png)