### PR TITLE
Change main field in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PLEASE. Help me update documetation.
+# PLEASE. Help me update documentation.
 [Doc.tpl](https://github.com/xdan/datetimepicker/blob/master/doc.tpl)
 This file will be automatically displayed on the site
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jquery-datetimepicker",
   "version": "2.5.1",
   "description": "jQuery Plugin DateTimePicker it is DatePicker and TimePicker in one",
-  "main": "jquery.datetimepicker.js",
+  "main": "build/jquery.datetimepicker.full.min.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "concat": "concat-cli -f bower_components/php-date-formatter/js/php-date-formatter.js jquery.datetimepicker.js bower_components/jquery-mousewheel/jquery.mousewheel.js -o build/jquery.datetimepicker.full.js",


### PR DESCRIPTION
In order for this package to be installed via npm and work with `require('jquery-datetimepicker')`, the `main` field should point to the builded script.