### PR TITLE
Allow the date formatter to be set from external

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -639,6 +639,9 @@
 				initDateFormatter();
 			}
 		},
+		setDateFormatter: function(dateFormatter) {
+			dateHelper = dateFormatter;
+		},
 		RFC_2822: 'D, d M Y H:i:s O',
 		ATOM: 'Y-m-d\TH:i:sP',
 		ISO_8601: 'Y-m-d\TH:i:sO',


### PR DESCRIPTION
This pull request adds the ability to set the date formatter from external. This way, MomentJS or any other date formatting/parsing library can be plugged in easily. For example:

```javascript
$.datetimepicker.setDateFormatter({
		parseDate: function (vDate, vFormat) {
			return moment(vDate, vFormat);
		},
		
		formatDate: function (vDate, vFormat) {
			return moment(vDate).format(vFormat);
		}
	});
```