### PR TITLE
fixed sync of input value to calendar when using MomentJS

### DIFF
--- a/doc.tpl
+++ b/doc.tpl
@@ -367,7 +367,7 @@ jQuery('#_datetimepicker_weekends_disable').datetimepicker({
 <pre><code data-language="javascript">$.datetimepicker.setDateFormatter({
     parseDate: function (date, format) {
         var d = moment(date, format);
-        return d.isValid() ? d : false;
+        return d.isValid() ? d.toDate() : false;
     },
     
     formatDate: function (date, format) {


### PR DESCRIPTION
moment(date, format) returns its own object, not Date object.
Then our isValidDate() retuns false because
`Object.prototype.toString.call(d) !== "[object Date]"`
is false.
The problem occurs when user types date/time directly into input field. In this case a calendar always shows currect date while input field has user's value. 