### PR TITLE
Allow blank values if 'options.allowBlank' is set

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1278,8 +1278,20 @@
 					return !isNaN(d.getTime());
 				};
 
-				_this.setCurrentTime = function (dTime) {
-					_this.currentTime = (typeof dTime === 'string') ? _this.strToDateTime(dTime) : _this.isValidDate(dTime) ? dTime : _this.now();
+				_this.setCurrentTime = function (dTime, requireValidDate) {
+					if (typeof dTime === 'string') {
+						_this.currentTime = _this.strToDateTime(dTime);
+					}
+					else if (_this.isValidDate(dTime)) {
+						_this.currentTime = dTime;
+					}
+					else if (!dTime && !requireValidDate && options.allowBlank) {
+						_this.currentTime = null;
+					}
+					else {
+						_this.currentTime = _this.now();
+					}
+					
 					datetimepicker.trigger('xchange.xdsoft');
 				};
 
@@ -1529,6 +1541,10 @@
 					xchangeTimer = setTimeout(function () {
 
 						if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+							//In case blanks are allowed, delay construction until we have a valid date 
+							if (options.allowBlank)
+								return;
+								
 							_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
 						}
 
@@ -2254,7 +2270,7 @@
 						}
 
 						triggerAfterOpen = true;
-						_xdsoft_datetime.setCurrentTime(getCurrentValue());
+						_xdsoft_datetime.setCurrentTime(getCurrentValue(), true);
 						if(options.mask) {
 							setMask(options);
 						}


### PR DESCRIPTION
Hi there,

in our project we require the value to be initial (null), but it's currently not working correctly, even with "allowBlank" set to true. This works only when you manually clear the date. In case the picker was not visible once, $(el).datetimepicker('getValue') always defaults to the current date, which is kind of pointless.

What I did is the following: 
- Changed setCurrentTime so that null-values are allowed if "allowBlank" is true
- Changed xchange handler, so that if no value is set, it does not default to now() but returns
- In the open event, force that setCurrentTime should not allow null, as the rendering needs this

This maybe a breaking change, since allowBlank defaults to true. In case no value is set on the input field and no initial value is passed via the options object, 'getValue' will now return null instead of now().

What do you think?
Thanks!