### PR TITLE
Today button not working anymore

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1444,7 +1444,7 @@
 				.find('.xdsoft_today_button')
 				.on('touchend mousedown.xdsoft', function () {
 					datetimepicker.data('changed', true);
-					_xdsoft_datetime.setCurrentTime(0);
+					_xdsoft_datetime.setCurrentTime(0, true);
 					datetimepicker.trigger('afterOpen.xdsoft');
 				}).on('dblclick.xdsoft', function () {
 					var currentDate = _xdsoft_datetime.getCurrentTime(), minDate, maxDate;


### PR DESCRIPTION
Fixed a problem with the today button which is not working anymore. As
far as I could figure out the reason is
"XDSoft_datetime.prototype.setCurrentTime" which is now setting the
current time to null which doesn't reset the displayed date. Also double
clicking on the today button wasn't working because the "currentDate"
variable is null.

Related issue is #449.