### PR TITLE
Added missing var definition

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -926,7 +926,8 @@
 				setPos,
 				timer = 0,
 				_xdsoft_datetime,
-				forEachAncestorOf;
+				forEachAncestorOf,
+				throttle;
 
 			if (options.id) {
 				datetimepicker.attr('id', options.id);


### PR DESCRIPTION
Fix for https://github.com/xdan/datetimepicker/pull/457
query.datetimepicker.js:1876 Uncaught ReferenceError: throttle is not defined