### PR TITLE
Fix bug: scrolling time div on touchscreens

### DIFF
--- a/build/jquery.datetimepicker.full.js
+++ b/build/jquery.datetimepicker.full.js
@@ -593,6 +593,9 @@ var DateFormatter;
 	}
 }(function ($) {
 	'use strict';
+	
+	var currentlyScrollingTimeDiv = false;
+	
 	var default_options  = {
 		i18n: {
 			ar: { // Arabic
@@ -2410,8 +2413,13 @@ var DateFormatter;
 				});
 
 			timebox
+				.on('touchmove', 'div', function () { currentlyScrollingTimeDiv = true; })
 				.on('touchend click.xdsoft', 'div', function (xdevent) {
 					xdevent.stopPropagation();
+					if (currentlyScrollingTimeDiv) {
+				        	currentlyScrollingTimeDiv = false;
+				        	return;
+				    	}
 					var $this = $(this),
 						currentTime = _xdsoft_datetime.currentTime;
 


### PR DESCRIPTION
On touchscreens, the default datetimepicker closes unexpectedly when trying to scroll on the time picker. This is because scrolling triggers touchend event, just like clicking. 

To fix, we use the touchmove event to determine that we are scrolling, not clicking, using a global variable.