### PR TITLE
solution to bower error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Install:
 2. Run `npm install`. npm will look at `package.json` and automatically install the necessary dependencies. 
 3. Run `bower install`, which installs front-end packages defined in `bower.json`.
 
+Notice: If you use Bower v1.5.2, you will get error: `The "main" field cannot contain minified files`
+You can regress to version 1.3.12
+
+1. `npm uninstall bower -g`
+2. `npm install -g bower@1.3.12`
+
 Build:
 
 - `npm run build`


### PR DESCRIPTION
Using Bower v1.5.2 to run bower install will get error: `The "main" field cannot contain minified files`
A solution is to  regress to version 1.3.12