### PR TITLE
#453 Setting input as readonly still allows the user to use the datetimepicker UI

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1636,7 +1636,7 @@
 								classes.push('xdsoft_disabled');
 							} else if (options.disabledWeekDays.indexOf(day) !== -1) {
 								classes.push('xdsoft_disabled');
-							}else if (input.is('[readonly]')) {
+							}else if (input.is('[disabled]')) {
 								classes.push('xdsoft_disabled');
 							}
 
@@ -1716,7 +1716,7 @@
 								classes.push('xdsoft_disabled');
 							} else if ((options.minDateTime !== false && options.minDateTime > optionDateTime) || ((options.disabledMinTime !== false && now.getTime() > _xdsoft_datetime.strtotime(options.disabledMinTime).getTime()) && (options.disabledMaxTime !== false && now.getTime() < _xdsoft_datetime.strtotime(options.disabledMaxTime).getTime()))) {
 								classes.push('xdsoft_disabled');
-							} else if (input.is('[readonly]')) {
+							} else if (input.is('[disabled]')) {
 								classes.push('xdsoft_disabled');
 							}
 


### PR DESCRIPTION
As discussed in the issue, there is a difference between a readonly element, and a disabled element. Readonly elements should not disable the UI, only disable the user from manually editing the resulting date string. This change corrects this issue.