### PR TITLE
Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -2001,6 +2001,10 @@
 					dateInputHasFixedAncestor = false;
 
 					forEachAncestorOf(dateInputElem, function (ancestorNode) {
+                        if (ancestorNode === null) {
+                            return false;
+                        }
+
 						if (options.contentWindow.getComputedStyle(ancestorNode).getPropertyValue('position') === 'fixed') {
 							dateInputHasFixedAncestor = true;
 							return false;


### PR DESCRIPTION
When an element that has been connected to datetimepicker object has been dynamically removed due to dynamic content changes the javascript starts throwing errors on window resize events regarding getComputedStyle receiving nulls in its 0 argument. Re-check the value before calling resolves the issue.

My case:
* jquery modal opens
* dt object attaches
* jquery modal closes
* base content changes
* another modal opens
* modal closes
* window trigger resize
* error

<img width="770" alt="screen shot 2017-05-07 at 17 32 54" src="https://cloud.githubusercontent.com/assets/19610073/25780029/85dcbd00-334b-11e7-92a2-564fa65d20ad.png">
