### PR TITLE
Fixed issue #575 from xdan repository - setPos lost positioning feature

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -2018,8 +2018,8 @@
 							verticalPosition -= windowScrollTop;
 						}
 					} else {
-						if (verticalPosition + dateInputElem.offsetHeight > windowHeight + windowScrollTop) {
-							verticalPosition = dateInputOffset.top - dateInputElem.offsetHeight + 1;
+						if (verticalPosition + datetimepicker[0].offsetHeight > windowHeight + windowScrollTop) {
+							verticalPosition = dateInputOffset.top - datetimepicker[0].offsetHeight + 1;
 						}
 					}
 


### PR DESCRIPTION
Fixed issue #575, but there is still a need to build the other files.
Now the datetimepicker is displayed above the input field when there is no space unterneath.
The bug was caused by taking the height of wrong dom element. Input element was taken instead of datetimepicker element.