### PR TITLE
The picker's offsetHeight is not calculated correctly when calendar is not generated.

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1562,10 +1562,6 @@
 					xchangeTimer = setTimeout(function () {
 
 						if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
-							//In case blanks are allowed, delay construction until we have a valid date
-							if (options.allowBlank)
-								return;
-
 							_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
 						}
 


### PR DESCRIPTION
If options.allowBlank is true, "setPos" does not set the picker position over the input field
when the input field is at the bottom of a page.

![screenshot1](https://user-images.githubusercontent.com/614087/26874496-42f71f12-4b97-11e7-88b7-b727e6668350.png)
