### PR TITLE
Fix broken time steps

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1771,7 +1771,7 @@ var datetimepickerFactory = function ($) {
 							for (i = 0, j = 0; i < (options.hours12 ? 12 : 24); i += 1) {
 								for (j = 0; j < 60; j += options.step) {
 									h = (i < 10 ? '0' : '') + i;
-									m = (j < 10 ? _xdsoft_datetime.now().getMinutes() : '') + j;
+									m = (j < 10 ? '0' : '') + j;
 									line_time(h, m);
 								}
 							}


### PR DESCRIPTION
I reverted one line to an older version. The change was breaking the time selection when using the "step" option. It occurred here:
https://github.com/xdan/datetimepicker/commit/b7dc5fe1d39cb1bd82b526613837fd2df80bcf47#diff-da024f311897af18bea3a00915b184ff

It's not clear to me exactly why this change was made, so feel free to reject this commit if it conflicts with the intended behavior. But in my application, I had a step option set to 30 minutes, which made the time appear in half hour increments, i.e., the times available are supposed to be

12:00
12:30
1:00
1:30

But after updating it shows some of the times based on the current minute of the system time. For instance, if you browse at 3:17, you see:

12:17
12:30
1:17
1:30

Assuming this is not intentional, it should be reverted. If it is intentional, please clarify and help me come up with a better fix.
