### PR TITLE
Sensitivity of scrollable select boxes on mobile

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -574,6 +574,7 @@ var datetimepickerFactory = function ($) {
 		initTime: true,
 		inline: false,
 		theme: '',
+		touchMovedThreshold: 5,
 
 		onSelectDate: function () {},
 		onSelectTime: function () {},
@@ -1003,19 +1004,29 @@ var datetimepickerFactory = function ($) {
 					return false;
 				});
 
+			var handleTouchMoved = function (event) {
+				this.touchStartPosition = this.touchStartPosition || event.originalEvent.touches[0]
+				var touchPosition = event.originalEvent.touches[0]
+				var xMovement = Math.abs(this.touchStartPosition.clientX - touchPosition.clientX)
+				var yMovement = Math.abs(this.touchStartPosition.clientY - touchPosition.clientY)
+				var distance = Math.sqrt(xMovement * xMovement + yMovement * yMovement)
+				if(distance > options.touchMovedThreshold) {
+					this.touchMoved = true;
+				}
+			}
+
 			month_picker
 				.find('.xdsoft_select')
 				.xdsoftScroller(options)
 				.on('touchstart mousedown.xdsoft', function (event) {
-					this.touchmoved = false;
+					this.touchMoved = false;
+					this.touchStartPosition = event.originalEvent.touches[0]
 					event.stopPropagation();
 					event.preventDefault();
 				})
-				.on('touchmove', '.xdsoft_option', function () {
-					this.touchmoved = true;
-				})
+				.on('touchmove', '.xdsoft_option', handleTouchMoved)
 				.on('touchend mousedown.xdsoft', '.xdsoft_option', function () {
-					if (!this.touchmoved) {
+					if (!this.touchMoved) {
 						if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
 							_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
 						}
@@ -1883,13 +1894,11 @@ var datetimepickerFactory = function ($) {
 
 			timebox
 				.on('touchstart', 'div', function (xdevent) {
-					this.touchmoved = false;
+					this.touchMoved = false;
 				})
-				.on('touchmove', 'div', function (xdevent) {
-					this.touchmoved = true;
-				})
+				.on('touchmove', 'div', handleTouchMoved)
 				.on('touchend click.xdsoft', 'div', function (xdevent) {
-					if (!this.touchmoved) {
+					if (!this.touchMoved) {
 						xdevent.stopPropagation();
 						var $this = $(this),
 							currentTime = _xdsoft_datetime.currentTime;


### PR DESCRIPTION
A previous fix, committed in https://github.com/xdan/datetimepicker/commit/63441fde fixed an issue with mobile scrolling but introduced a new bug. If you use touch to scroll through select box options, it originally would select a new value as soon as you touch anything, which made it impossible to scroll. I updated the behavior so that it would not select an option after the touch position has moved.

This worked fine on emulators, but it introduced a new problem on actual mobile devices, which is that it's very hard to touch something and release without moving your finger at all. This made it extremely difficult to actually select an option. My colleague, Wayne Dietz, helpfully took over this issue and added a threshold variable, so the intent is clear that you are scrolling when you move the box more than 5 pixels, but are selecting an option if moving a very small amount.