### PR TITLE
Set the Seconds and the Milliseconds on defaultTime

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1311,6 +1311,8 @@ var datetimepickerFactory = function ($) {
 						time = _this.strtotime(options.defaultTime);
 						d.setHours(time.getHours());
 						d.setMinutes(time.getMinutes());
+						d.setSeconds(time.getSeconds());
+						d.setMilliseconds(time.getMilliseconds());
 					}
 					return d;
 				};


### PR DESCRIPTION
When we set the default time to e.g. `00:00:00` we want to get a default date to `2018-01-10 00:00:00.000`, dot `2018-01-10 00:00:26:483`...