### PR TITLE
Fix issue #641

### DIFF
--- a/doc.tpl
+++ b/doc.tpl
@@ -372,6 +372,18 @@ jQuery('#_datetimepicker_weekends_disable').datetimepicker({
     
     formatDate: function (date, format) {
         return moment(date).format(format);
+    },
+
+    //Optional if using mask input
+    formatMask: function(format){
+        return format
+            .replace(/Y{4}/g, '9999')
+            .replace(/Y{2}/g, '99')
+            .replace(/M{2}/g, '19')
+            .replace(/D{2}/g, '39')
+            .replace(/H{2}/g, '29')
+            .replace(/m{2}/g, '59')
+            .replace(/s{2}/g, '59');
     }
 });
 </code></pre>
@@ -381,6 +393,8 @@ jQuery('#_datetimepicker_weekends_disable').datetimepicker({
   formatTime:'h:mm a',
   formatDate:'DD.MM.YYYY'
 });</code></pre>
+<p>Because of its popularity, moment.js has a pre-defined configuration that can be enabled with:</p>
+<pre><code class="language-javascript">$.datetimepicker.setDateFormatter('moment');</code></pre>
 <hr id="range" />
 <h4>Range between date<a href="#range">#</a></h4>
 <p><strong>javaScript</strong></p>

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -2249,15 +2249,8 @@ var datetimepickerFactory = function ($) {
 				}
 
 				if (options.mask === true) {
-					if (typeof moment != 'undefined') {
-						options.mask = options.format
-							.replace(/Y{4}/g, '9999')
-							.replace(/Y{2}/g, '99')
-							.replace(/M{2}/g, '19')
-							.replace(/D{2}/g, '39')
-							.replace(/H{2}/g, '29')
-							.replace(/m{2}/g, '59')
-							.replace(/s{2}/g, '59');
+					if (dateHelper.formatMask) {
+						options.mask = dateHelper.formatMask(options.format)
 					} else {
 						options.mask = options.format
 							.replace(/Y/g, '9999')


### PR DESCRIPTION
This removes the reference to the global moment function. A custom masking function must now accompany any custom formatter configured via setDateFormatter. This will prevent moment.js from breaking pages that use the default formatter.