### PR TITLE
Fix touch events crashing on desktop

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1060,11 +1060,12 @@ var datetimepickerFactory = function ($) {
 
 			var handleTouchMoved = function (event) {
 				var evt = event.originalEvent;
-				this.touchStartPosition = this.touchStartPosition || evt.touches[0]
-				var touchPosition = evt.touches[0]
-				var xMovement = Math.abs(this.touchStartPosition.clientX - touchPosition.clientX)
-				var yMovement = Math.abs(this.touchStartPosition.clientY - touchPosition.clientY)
-				var distance = Math.sqrt(xMovement * xMovement + yMovement * yMovement)
+				var position = evt.touches ? evt.touches[0] : evt;
+				this.touchStartPosition = this.touchStartPosition || position;
+				var touchPosition = position;
+				var xMovement = Math.abs(this.touchStartPosition.clientX - touchPosition.clientX);
+				var yMovement = Math.abs(this.touchStartPosition.clientY - touchPosition.clientY);
+				var distance = Math.sqrt(xMovement * xMovement + yMovement * yMovement);
 				if(distance > options.touchMovedThreshold) {
 					this.touchMoved = true;
 				}

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1060,9 +1060,8 @@ var datetimepickerFactory = function ($) {
 
 			var handleTouchMoved = function (event) {
 				var evt = event.originalEvent;
-				var position = evt.touches ? evt.touches[0] : evt;
-				this.touchStartPosition = this.touchStartPosition || position;
-				var touchPosition = position;
+				var touchPosition = evt.touches ? evt.touches[0] : evt;
+				this.touchStartPosition = this.touchStartPosition || touchPosition;
 				var xMovement = Math.abs(this.touchStartPosition.clientX - touchPosition.clientX);
 				var yMovement = Math.abs(this.touchStartPosition.clientY - touchPosition.clientY);
 				var distance = Math.sqrt(xMovement * xMovement + yMovement * yMovement);

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1059,8 +1059,9 @@ var datetimepickerFactory = function ($) {
 				});
 
 			var handleTouchMoved = function (event) {
-				this.touchStartPosition = this.touchStartPosition || event.originalEvent.touches[0]
-				var touchPosition = event.originalEvent.touches[0]
+				var evt = event.originalEvent;
+				this.touchStartPosition = this.touchStartPosition || evt.touches[0]
+				var touchPosition = evt.touches[0]
 				var xMovement = Math.abs(this.touchStartPosition.clientX - touchPosition.clientX)
 				var yMovement = Math.abs(this.touchStartPosition.clientY - touchPosition.clientY)
 				var distance = Math.sqrt(xMovement * xMovement + yMovement * yMovement)
@@ -1073,8 +1074,9 @@ var datetimepickerFactory = function ($) {
 				.find('.xdsoft_select')
 				.xdsoftScroller(options)
 				.on('touchstart mousedown.xdsoft', function (event) {
+					var evt = event.originalEvent;
 					this.touchMoved = false;
-					this.touchStartPosition = event.originalEvent.touches[0]
+					this.touchStartPosition = evt.touches ? evt.touches[0] : evt;
 					event.stopPropagation();
 					event.preventDefault();
 				})


### PR DESCRIPTION
Fixes https://github.com/xdan/datetimepicker/issues/636 by actually checking the event type for mouse vs. touch

Fairly critical bug because it's a guaranteed throw.