### PR TITLE
Object.values not supported in IE

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -728,7 +728,8 @@ var datetimepickerFactory = function ($) {
 	}
 
 	var isFormatStandard = function(format){
-		return Object.values(standardFormats).indexOf(format) === -1 ? false : true;
+		return $.map(standardFormats, function (val) { return val })
+			.indexOf(format) === -1 ? false : true;
 	}
 
 	$.extend($.datetimepicker, standardFormats);


### PR DESCRIPTION
In reference to code review for #642.
Maybe using something like [eslint](https://github.com/amilajack/eslint-plugin-compat) can help catching potential compatibility issues in the future.