### PR TITLE
Conflict with other calendar pickers

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -928,7 +928,7 @@ var datetimepickerFactory = function ($) {
 		});
 	};
 
-	$.fn.datetimepicker = function (opt, opt2) {
+	$.fn.xdsoft_datetimepicker = function (opt, opt2) {
 		var result = this,
 			KEY0 = 48,
 			KEY9 = 57,
@@ -2656,7 +2656,7 @@ var datetimepickerFactory = function ($) {
 		return result;
 	};
 
-	$.fn.datetimepicker.defaults = default_options;
+	$.fn.xdsoft_datetimepicker.defaults = default_options;
 
 	function HighlightedDate(date, desc, style) {
 		"use strict";


### PR DESCRIPTION
Assigned a unique prefix to datetimepicker function

## Fixes #
Conflict with Trent Richardson's [jQuery UI Timepicker Addon](https://github.com/trentrichardson/jQuery-Timepicker-Addon), which also defines the same function name $.fn.datetimepicker as a jQuery plugin.
I've seen the conflict in websites that makes use of both the plugins.
Since the prefix xdsoft_ has been largely used anyway, I thought it can be used for the plugin name as well, to avoid any future conflict, since the name "datetimepicker" it's likely to conflict again in future.
