### PR TITLE
fix scroll too fast issue on macOS with trackpad2 or magic mouse

### DIFF
--- a/build/jquery.datetimepicker.full.js
+++ b/build/jquery.datetimepicker.full.js
@@ -905,7 +905,7 @@ var datetimepickerFactory = function ($) {
 				timeboxparent.on('mousewheel', function (event) {
 					var top = Math.abs(parseInt(timebox.css('marginTop'), 10));
 
-					top = top - (event.deltaY * 20);
+					top = top - (event.deltaY * 1);
 					if (top < 0) {
 						top = 0;
 					}

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -905,7 +905,7 @@ var datetimepickerFactory = function ($) {
 				timeboxparent.on('mousewheel', function (event) {
 					var top = Math.abs(parseInt(timebox.css('marginTop'), 10));
 
-					top = top - (event.deltaY * 20);
+					top = top - (event.deltaY * 1);
 					if (top < 0) {
 						top = 0;
 					}


### PR DESCRIPTION
## Fixes #

fix scroll too fast issue on macOS with Magic Trackpad2 or Magic Mouse, but haven't compile min.js