### PR TITLE
Fix Travis CI "sh: 0: Can't open /etc/init.d/xvfb" issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
   - "8"
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
+services:
+  - xvfb


### PR DESCRIPTION
## Checklist before pull request

* [ ] There is an associated issue that is labelled 'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `npm test` locally
* [ ] There are new or updated tests validating the change

## Fixes

Travis CI was broken for a while:

![image](https://user-images.githubusercontent.com/3691490/115881574-758de480-a47e-11eb-8762-fc35d93b7916.png)

This pull request will fix it.



