### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -2432,8 +2432,8 @@ var datetimepickerFactory = function ($) {
 						val = this.value,
 						pos = this.selectionStart
 
-					    var valueBeforeCursor = val.substr(0, pos);
-					    var valueAfterPaste = val.substr(pos + pastedData.length);
+					    var valueBeforeCursor = val.slice(0, pos);
+					    var valueAfterPaste = val.slice(pos + pastedData.length);
 
 					    val = valueBeforeCursor + pastedData + valueAfterPaste;
 					    pos += pastedData.length;
@@ -2478,7 +2478,7 @@ var datetimepickerFactory = function ($) {
 						//   value char - keep incrementing position while on separator char and we still have room
 						//   del char   - keep decrementing position while on separator char and we still have room
 						while (true) {
-						  var maskValueAtCurPos = options.mask.substr(pos, 1);
+						  var maskValueAtCurPos = options.mask.slice(pos, pos+1);
 						  var posShorterThanMaskLength = pos < options.mask.length;
 						  var posGreaterThanZero = pos > 0;
 						  var notNumberOrPlaceholder = /[^0-9_]/;
@@ -2504,19 +2504,19 @@ var datetimepickerFactory = function ($) {
 
 						  // if we have a selection length we will wipe out entire selection and replace with default template for that range
 						  var defaultBlank = options.mask.replace(/[0-9]/g, '_');
-						  var defaultBlankSelectionReplacement = defaultBlank.substr(pos, selLength);
-						  var selReplacementRemainder = defaultBlankSelectionReplacement.substr(1) // might be empty
+						  var defaultBlankSelectionReplacement = defaultBlank.slice(pos, pos+selLength);
+						  var selReplacementRemainder = defaultBlankSelectionReplacement.slice(1) // might be empty
 
-						  var valueBeforeSel = val.substr(0, pos);
+						  var valueBeforeSel = val.slice(0, pos);
 						  var insertChars = digit + selReplacementRemainder;
-						  var charsAfterSelection = val.substr(pos + selLength);
+						  var charsAfterSelection = val.slice(pos + selLength);
 
 						  val = valueBeforeSel + insertChars + charsAfterSelection
 
 						} else {
-						  var valueBeforeCursor = val.substr(0, pos);
+						  var valueBeforeCursor = val.slice(0, pos);
 						  var insertChar = digit;
-						  var valueAfterNextChar = val.substr(pos + 1);
+						  var valueAfterNextChar = val.slice(pos + 1);
 
 						  val = valueBeforeCursor + insertChar + valueAfterNextChar
 						}
@@ -2535,7 +2535,7 @@ var datetimepickerFactory = function ($) {
 						// resume cursor location
 						pos += (key === BACKSPACE) ? 0 : 1;
 						// don't stop on a separator, continue whatever direction you were going
-						while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
+						while (/[^0-9_]/.test(options.mask.slice(pos, pos+1)) && pos < options.mask.length && pos > 0) {
 						    pos += (key === BACKSPACE) ? 0 : 1;
 						}
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.

## Checklist before pull request
* [ ] There is an associated issue that is labelled 'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `npm test` locally
* [ ] There are new or updated tests validating the change

## Fixes
Nothing is broken at this time but we remove a possible issue in the future
