### PR TITLE
Fix 2 bugs

### DIFF
--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -2264,6 +2264,16 @@ var datetimepickerFactory = function ($) {
                 } else {
                     datetimepickerCss[verticalAnchorEdge] = verticalPosition;
                 }
+				/**
+				 *  Fixes a bug which happens if:
+				 *  clicking prev/next while viewing a 6 week month adjusts the height of the calendar to less
+				 *  for the prev/next month with 5 only weeks, in which case **when the popup is above the input** by the
+     				 *  time the mouseup event occurs the prev/next button is no longer underneath the mouse pointer, rather 
+	  			 *  whatever was behind the calendar popup, and if that whatever is also a disabled form element then
+       				 *  the mouseup event is swallowed up and the prev/next repeat becomes an infinite loop.
+	    			 *  One solution is set a fixed height, so that the UI doesn't jump around for better UX when above.
+				 */
+				calendar.css({'min-height':verticalAnchorEdge == 'bottom' ? '180px' : ''})
 
 				datetimepicker.css(datetimepickerCss);
 			};

--- a/jquery.datetimepicker.js
+++ b/jquery.datetimepicker.js
@@ -1609,7 +1609,7 @@ var datetimepickerFactory = function ($) {
 			});
 			month_picker
 				.find('.xdsoft_prev,.xdsoft_next')
-				.on('touchend mousedown.xdsoft', function () {
+				.on('touchstart mousedown.xdsoft', function () {
 					var $this = $(this),
 						timer = 0,
 						stop = false;
@@ -1636,7 +1636,7 @@ var datetimepickerFactory = function ($) {
 
 			timepicker
 				.find('.xdsoft_prev,.xdsoft_next')
-				.on('touchend mousedown.xdsoft', function () {
+				.on('touchstart mousedown.xdsoft', function () {
 					var $this = $(this),
 						timer = 0,
 						stop = false,


### PR DESCRIPTION
## Checklist before pull request
* [ ] There is an associated issue that is labelled 'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `npm test` locally
* [ ] There are new or updated tests validating the change

## Fixes #
Fix mobile not being able to auto repeat prev/next for calendar
Fix forever calendar prev/next click when viewing a 6 week month, and the popup is above the input (css bottom is set), and a disabled form input is behind the clicked calendar prev/next button
